### PR TITLE
v1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.2.8
+
+- `FunctionReflection.methodInvocationFromMap` and `FunctionReflection.methodInvocation`:
+  - Better handling of unresolved parameters values.
+    Attempts to resolve 2 times, to allow entities references through cache.
+- `Reflection`:
+  - `castList`, `castSet`, `castIterable`, `castMap`, `castCollection`:
+    - Added parameter `nullable`.
+
 ## 1.2.7
 
 - `TypeInfo`:

--- a/example/reflection_factory_bridge_example.reflection.g.dart
+++ b/example/reflection_factory_bridge_example.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.7
+// BUILDER: reflection_factory/1.2.8
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -35,7 +35,7 @@ class User$reflection extends ClassReflection<User> {
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   User$reflection withObject([User? obj]) => User$reflection(obj);

--- a/example/reflection_factory_example.reflection.g.dart
+++ b/example/reflection_factory_example.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.7
+// BUILDER: reflection_factory/1.2.8
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -35,7 +35,7 @@ class User$reflection extends ClassReflection<User> {
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   User$reflection withObject([User? obj]) => User$reflection(obj);

--- a/lib/src/reflection_factory_base.dart
+++ b/lib/src/reflection_factory_base.dart
@@ -20,7 +20,7 @@ import 'reflection_factory_type.dart';
 /// Class with all registered reflections ([ClassReflection]).
 class ReflectionFactory {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.2.7';
+  static const String VERSION = '1.2.8';
 
   static final ReflectionFactory _instance = ReflectionFactory._();
 
@@ -145,73 +145,112 @@ abstract class Reflection<O> {
   int get reflectionLevel;
 
   /// Cast [list] to [classType] if [type] == [classType] or return `null`.
-  List? castList(List list, Type type) {
+  /// - If [nullable] is `true` casts to a [List] of nullable values.
+  List? castList(List list, Type type, {bool nullable = false}) {
     if (type == reflectedType) {
-      if (list is List<O>) {
-        return list;
+      if (nullable) {
+        if (list is List<O?>) {
+          return list;
+        } else {
+          return List<O?>.from(list);
+        }
       } else {
-        return List<O>.from(list);
+        if (list is List<O>) {
+          return list;
+        } else {
+          return List<O>.from(list);
+        }
       }
     } else if (type == dynamic) {
       return List<dynamic>.from(list);
     } else if (type == Object) {
-      return List<Object>.from(list);
+      return nullable ? List<Object?>.from(list) : List<Object>.from(list);
     }
 
     var typeInfo = TypeInfo.fromType(type);
 
     List? callCast<E>() => list.cast<E>();
+    List? callCastNullable<E>() => list.cast<E?>();
 
-    var l = typeInfo.callCasted(callCast);
+    var l = nullable
+        ? typeInfo.callCasted(callCastNullable)
+        : typeInfo.callCasted(callCast);
+
     return l;
   }
 
   /// Cast [set] to [classType] if [type] == [classType] or return `null`.
-  Set? castSet(Set set, Type type) {
+  /// - If [nullable] is `true` casts to a [Set] of nullable values.
+  Set? castSet(Set set, Type type, {bool nullable = false}) {
     if (type == reflectedType) {
-      if (set is Set<O>) {
-        return set;
+      if (nullable) {
+        if (set is Set<O?>) {
+          return set;
+        } else {
+          return Set<O?>.from(set);
+        }
       } else {
-        return Set<O>.from(set);
+        if (set is Set<O>) {
+          return set;
+        } else {
+          return Set<O>.from(set);
+        }
       }
     } else if (type == dynamic) {
       return Set<dynamic>.from(set);
     } else if (type == Object) {
-      return Set<Object>.from(set);
+      return nullable ? Set<Object?>.from(set) : Set<Object>.from(set);
     }
 
     var typeInfo = TypeInfo.fromType(type);
 
     Set? callCast<E>() => set.cast<E>();
+    Set? callCastNullable<E>() => set.cast<E?>();
 
-    var l = typeInfo.callCasted(callCast);
+    var l = nullable
+        ? typeInfo.callCasted(callCastNullable)
+        : typeInfo.callCasted(callCast);
+
     return l;
   }
 
   /// Cast [itr] to [classType] if [type] == [classType] or return `null`.
-  Iterable? castIterable(Iterable itr, Type type) {
+  /// - If [nullable] is `true` casts to an [Iterable] of nullable values.
+  Iterable? castIterable(Iterable itr, Type type, {bool nullable = false}) {
     if (type == reflectedType) {
-      if (itr is Iterable<O>) {
-        return itr;
+      if (nullable) {
+        if (itr is Iterable<O?>) {
+          return itr;
+        } else {
+          return itr.cast<O?>();
+        }
       } else {
-        return itr.cast<O>();
+        if (itr is Iterable<O>) {
+          return itr;
+        } else {
+          return itr.cast<O>();
+        }
       }
     } else if (type == dynamic) {
       return itr.cast<dynamic>();
     } else if (type == Object) {
-      return itr.cast<Object>();
+      return nullable ? itr.cast<Object?>() : itr.cast<Object>();
     }
 
     var typeInfo = TypeInfo.fromType(type);
 
     Iterable? callCast<E>() => itr.cast<E>();
+    Iterable? callCastNullable<E>() => itr.cast<E>();
 
-    var l = typeInfo.callCasted(callCast);
+    var l = nullable
+        ? typeInfo.callCasted(callCastNullable)
+        : typeInfo.callCasted(callCast);
     return l;
   }
 
   /// Cast [map] values to [classType] if [type] == [classType] or return `null`.
-  Map? castMap(Map map, TypeInfo typeInfo) {
+  /// - If [nullable] is `true` casts to a [Map] of nullable values.
+  Map? castMap(Map map, TypeInfo typeInfo, {bool nullable = false}) {
     if (!typeInfo.isMap) {
       return map;
     }
@@ -219,75 +258,56 @@ abstract class Reflection<O> {
     var keyType = typeInfo.argumentType(0) ?? TypeInfo.tDynamic;
     var valueType = typeInfo.argumentType(1) ?? TypeInfo.tDynamic;
 
-    if (keyType.isString) {
-      if (valueType.type == reflectedType) {
-        if (map is Map<String, O>) {
-          return map;
-        } else {
-          return map
-              .map<String, O>((key, value) => MapEntry<String, O>(key, value));
-        }
-      } else if (valueType.isDynamic) {
-        return map.map<String, dynamic>(
-            (key, value) => MapEntry<String, dynamic>(key, value));
-      } else if (valueType.isObject) {
-        return map.map<String, Object>(
-            (key, value) => MapEntry<String, Object>(key, value));
-      }
-    } else if (keyType.isObject) {
-      if (valueType.type == reflectedType) {
-        if (map is Map<Object, O>) {
-          return map;
-        } else {
-          return map
-              .map<Object, O>((key, value) => MapEntry<Object, O>(key, value));
-        }
-      } else if (valueType.isDynamic) {
-        return map.map<Object, dynamic>(
-            (key, value) => MapEntry<Object, dynamic>(key, value));
-      } else if (valueType.isObject) {
-        return map.map<Object, Object>(
-            (key, value) => MapEntry<Object, Object>(key, value));
-      }
-    } else if (keyType.isDynamic) {
-      if (valueType.type == reflectedType) {
-        if (map is Map<dynamic, O>) {
-          return map;
-        } else {
-          return map.map<dynamic, O>(
-              (key, value) => MapEntry<dynamic, O>(key, value));
-        }
-      } else if (valueType.isDynamic) {
-        return map.map<dynamic, dynamic>(
-            (key, value) => MapEntry<dynamic, dynamic>(key, value));
-      } else if (valueType.isObject) {
-        return map.map<dynamic, Object>(
-            (key, value) => MapEntry<dynamic, Object>(key, value));
-      }
+    if (valueType.type == reflectedType) {
+      Map? callKey<K>() => map is Map<K, O>
+          ? map
+          : map.map<K, O>((key, value) => MapEntry<K, O>(key, value));
+      Map? callKeyNullable<K>() => map is Map<K, O?>
+          ? map
+          : map.map<K, O?>((key, value) => MapEntry<K, O?>(key, value));
+
+      var m = nullable
+          ? keyType.callCasted(callKeyNullable)
+          : keyType.callCasted(callKey);
+
+      return m;
+    } else {
+      Map? callKey<K>() => valueType.callCasted(<V>() {
+            return map is Map<K, V>
+                ? map
+                : map.map<K, V>((key, value) => MapEntry<K, V>(key, value));
+          });
+
+      Map? callKeyNullable<K>() => valueType.callCasted(<V>() {
+            return map is Map<K, V?>
+                ? map
+                : map.map<K, V?>((key, value) => MapEntry<K, V?>(key, value));
+          });
+
+      var m = nullable
+          ? keyType.callCasted(callKeyNullable)
+          : keyType.callCasted(callKey);
+      return m;
     }
-
-    Map? callKey<K>() => valueType.callCasted(<V>() {
-          return map.map<K, V>((key, value) => MapEntry<K, V>(key, value));
-        });
-
-    var m = keyType.callCasted(callKey);
-    return m;
   }
 
   /// Cast [o] to a collection represented by [typeInfo].
-  Object? castCollection(dynamic o, TypeInfo typeInfo) {
+  /// - If [nullable] is `true` casts to a collection of nullable values.
+  /// - See: [castList], [castSet], [castIterable], [castMap].
+  Object? castCollection(dynamic o, TypeInfo typeInfo,
+      {bool nullable = false}) {
     if (o == null) return null;
 
     var mainType = typeInfo.argumentType(0) ?? typeInfo;
 
     if (typeInfo.isSet) {
-      return castSet(o, mainType.type);
+      return castSet(o, mainType.type, nullable: nullable);
     } else if (typeInfo.isList) {
-      return castList(o, mainType.type);
+      return castList(o, mainType.type, nullable: nullable);
     } else if (typeInfo.isIterable) {
-      return castIterable(o, mainType.type);
+      return castIterable(o, mainType.type, nullable: nullable);
     } else if (typeInfo.isMap) {
-      return castMap(o, typeInfo);
+      return castMap(o, typeInfo, nullable: nullable);
     }
 
     return null;
@@ -1148,7 +1168,7 @@ abstract class ClassReflection<O> extends Reflection<O>
           autoResetEntityCache: autoResetEntityCache);
     } else {
       throw StateError(
-          "JSON needs to be a Map to decode a class object: $className");
+          "JSON needs to be a Map to decode a class (`$className`) object. JSON type: `${json.runtimeType}`");
     }
   }
 
@@ -1206,7 +1226,7 @@ abstract class ClassReflection<O> extends Reflection<O>
       return o;
     } catch (e) {
       // Tries a second parameter resolution if some value was resolved.
-      // This will allow use of the  current cached entities in a `JsonEntityCache`
+      // This will allow use of the current cached entities in a `JsonEntityCache`
       // (if used by `fieldValueResolver`).
       var map2 = methodInvocation.parametersToMap();
 
@@ -2282,6 +2302,8 @@ class FieldReflection<O, T> extends ElementReflection<O>
 
 final Object absentParameterValue = _AbsentParameterValue();
 
+final Object unresolvedParameterValue = _UnresolvedParameterValue();
+
 class _AbsentParameterValue {
   const _AbsentParameterValue();
 
@@ -2289,7 +2311,23 @@ class _AbsentParameterValue {
   bool operator ==(Object other) => identical(this, other);
 
   @override
-  int get hashCode => 0;
+  int get hashCode => 1;
+
+  @override
+  String toString() => '<absent_parameter>';
+}
+
+class _UnresolvedParameterValue {
+  const _UnresolvedParameterValue();
+
+  @override
+  bool operator ==(Object other) => identical(this, other);
+
+  @override
+  int get hashCode => 2;
+
+  @override
+  String toString() => '<unresolved_parameter>';
 }
 
 /// Base class fro methods and constructors.
@@ -2543,6 +2581,33 @@ abstract class FunctionReflection<O, R> extends ElementReflection<O>
       {FieldValueResolver? reviver,
       FieldNameResolver? nameResolver,
       bool jsonName = false}) {
+    // Resolve the valie, reviving it if needed:
+    Object? resolveValue(
+        ParameterReflection p, String pName, Object? val, bool contains) {
+      if (reviver != null) {
+        var type = p.type;
+        var valRevived = reviver(pName, val, type);
+        if (valRevived != null) {
+          if (valRevived is List &&
+              type.isListEntity &&
+              valRevived.any((e) => e == null)) {
+            var valRevivedUnresolved =
+                valRevived.map((e) => e ?? unresolvedParameterValue).toList();
+            return valRevivedUnresolved;
+          }
+          return valRevived;
+        }
+        if (contains) {
+          return val == null ? null : unresolvedParameterValue;
+        } else {
+          return absentParameterValue;
+        }
+      } else {
+        if (val != null) return val;
+        return contains ? null : absentParameterValue;
+      }
+    }
+
     if (jsonName) {
       var fieldsAliases = classReflection.fieldsJsonNameAliases;
       var fieldsAliasesReverse =
@@ -2576,12 +2641,7 @@ abstract class FunctionReflection<O, R> extends ElementReflection<O>
           contains = true;
         }
 
-        if (reviver != null) {
-          val = reviver(pName, val, p.type);
-        }
-
-        if (val != null) return val;
-        return contains ? null : absentParameterValue;
+        return resolveValue(p, pName, val, contains);
       });
     } else {
       return methodInvocation((p) {
@@ -2599,12 +2659,7 @@ abstract class FunctionReflection<O, R> extends ElementReflection<O>
           contains = true;
         }
 
-        if (reviver != null) {
-          val = reviver(pName, val, p.type);
-        }
-
-        if (val != null) return val;
-        return contains ? null : absentParameterValue;
+        return resolveValue(p, pName, val, contains);
       });
     }
   }
@@ -2612,70 +2667,97 @@ abstract class FunctionReflection<O, R> extends ElementReflection<O>
   /// Creates a [MethodInvocation] using [parametersProvider].
   MethodInvocation<O> methodInvocation(
       Object? Function(ParameterReflection parameter) parametersProvider) {
-    var normalParameters = this
-        .normalParameters
-        .map((p) => MapEntry<String, Object?>(p.name, parametersProvider(p)))
-        .toList();
+    final normalParameters = this.normalParameters;
+    final optionalParameters = this.optionalParameters;
+    final namedParameters = this.namedParameters;
 
-    var optionalParameters = this
-        .optionalParameters
-        .map((p) => MapEntry<String, Object?>(p.name, parametersProvider(p)))
-        .toList();
+    MapEntry<String, Object?> resolveParameterEntry(ParameterReflection p) =>
+        MapEntry<String, Object?>(p.name, parametersProvider(p));
 
-    while (optionalParameters.isNotEmpty) {
-      var lastIndex = optionalParameters.length - 1;
+    var normalParametersEntries =
+        normalParameters.map(resolveParameterEntry).toList();
 
-      var entry = optionalParameters[lastIndex];
+    var optionalParametersEntries =
+        optionalParameters.map(resolveParameterEntry).toList();
+
+    var namedParametersEntries = Map<String, dynamic>.fromEntries(
+        namedParameters.values.map(resolveParameterEntry));
+
+    // If has some unresolved parameter tries to resolve it again.
+    // This will allow use of the current cached entities in
+    // a `JsonEntityCache` (if in use).
+    if (_hasUnresolvedParameterValue(normalParametersEntries) ||
+        _hasUnresolvedParameterValue(optionalParametersEntries) ||
+        _hasUnresolvedParameterValue(namedParametersEntries.entries)) {
+      normalParametersEntries =
+          normalParameters.map(resolveParameterEntry).toList();
+
+      optionalParametersEntries =
+          optionalParameters.map(resolveParameterEntry).toList();
+
+      namedParametersEntries = Map<String, dynamic>.fromEntries(
+          namedParameters.values.map(resolveParameterEntry));
+
+      if (_hasUnresolvedParameterValue(normalParametersEntries) ||
+          _hasUnresolvedParameterValue(optionalParametersEntries) ||
+          _hasUnresolvedParameterValue(namedParametersEntries.entries)) {
+        throw StateError(
+            "Unresolved parameter value> normal: ${normalParametersEntries.asStringSimple} ; "
+            "optional: ${optionalParametersEntries.asStringSimple} ; "
+            "named: ${namedParametersEntries.entries.asStringSimple}");
+      }
+    }
+
+    while (optionalParametersEntries.isNotEmpty) {
+      var lastIndex = optionalParametersEntries.length - 1;
+
+      var entry = optionalParametersEntries[lastIndex];
       var value = entry.value;
-      var isAbsent = absentParameterValue == value;
+      var isAbsent = value.isAbsentParameterValue;
       if (value != null && !isAbsent) break;
 
       var lastParam = this.optionalParameters[lastIndex];
 
       if (isAbsent) {
-        optionalParameters.removeAt(lastIndex);
+        optionalParametersEntries.removeAt(lastIndex);
       } else {
         if (lastParam.hasDefaultValue || lastParam.nullable) {
-          optionalParameters.removeAt(lastIndex);
+          optionalParametersEntries.removeAt(lastIndex);
         } else {
           throw StateError(
-              "Invalid optional parameter value: $optionalParameters != ${this.optionalParameters}");
+              "Invalid optional parameter value: $optionalParametersEntries != ${this.optionalParameters}");
         }
       }
     }
 
-    _removeAbsentParameterValue(normalParameters);
-    _removeAbsentParameterValue(optionalParameters);
+    for (var k in namedParametersEntries.keys.toList(growable: false)) {
+      var p = namedParameters[k]!;
+      Object? value = namedParametersEntries[k];
 
-    var namedParameters =
-        Map<String, dynamic>.fromEntries(this.namedParameters.entries.map((e) {
-      var p = e.value;
-
-      var value = parametersProvider(p);
-
-      var isAbsent = absentParameterValue == value;
+      var isAbsent = value.isAbsentParameterValue;
 
       if ((value == null || isAbsent) &&
           (p.nullable || p.hasDefaultValue) &&
           !p.required) {
-        return null;
-      } else {
-        if (isAbsent) {
-          throw StateError("Required named parameter `${p.name}` "
-              "${p.hasJsonNameAlias ? '(jsonName: p.jsonName)' : ''} "
-              "for `MethodInvocation[${classReflection.classType}.$name]`: $p");
-        }
-        return MapEntry(e.key, value);
+        namedParametersEntries.remove(k);
+      } else if (isAbsent) {
+        throw StateError("Required named parameter `${p.name}` "
+            "${p.hasJsonNameAlias ? '(jsonName: p.jsonName)' : ''} "
+            "for `MethodInvocation[${classReflection.classType}.$name]`: $p");
       }
-    }).whereType<MapEntry<String, dynamic>>());
+    }
 
-    var normalParametersValues = normalParameters.map((e) => e.value).toList();
+    _removeAbsentParameterValue(normalParametersEntries);
+    _removeAbsentParameterValue(optionalParametersEntries);
+
+    var normalParametersValues =
+        normalParametersEntries.map((e) => e.value).toList();
     var optionalParametersValues =
-        optionalParameters.map((e) => e.value).toList();
+        optionalParametersEntries.map((e) => e.value).toList();
 
     var positionalParametersNames = <String>[
-      ...normalParameters.map((e) => e.key),
-      ...optionalParameters.map((e) => e.key),
+      ...normalParametersEntries.map((e) => e.key),
+      ...optionalParametersEntries.map((e) => e.key),
     ];
 
     return MethodInvocation<O>.withPositionalParametersNames(
@@ -2684,7 +2766,7 @@ abstract class FunctionReflection<O, R> extends ElementReflection<O>
       positionalParametersNames,
       normalParametersValues,
       optionalParametersValues,
-      namedParameters,
+      namedParametersEntries,
     );
   }
 
@@ -2692,12 +2774,25 @@ abstract class FunctionReflection<O, R> extends ElementReflection<O>
     for (var i = parameters.length - 1; i >= 0; --i) {
       var entry = parameters[i];
       var value = entry.value;
-      var isAbsent = absentParameterValue == value;
+      var isAbsent = value.isAbsentParameterValue;
       if (isAbsent) {
         parameters[i] = MapEntry<String, Object?>(entry.key, null);
       }
     }
   }
+
+  bool _hasUnresolvedParameterValue(Iterable parameters) => parameters.any((e) {
+        Object? val = e is MapEntry ? e.value : e;
+        if (val.isUnresolvedParameterValue) {
+          return true;
+        } else if (val is Iterable) {
+          return _hasUnresolvedParameterValue(val);
+        } else if (val is Map) {
+          return _hasUnresolvedParameterValue(val.values);
+        } else {
+          return false;
+        }
+      });
 
   /// Invoke this method.
   R invoke(Iterable<Object?>? positionalArguments,
@@ -2727,6 +2822,37 @@ abstract class FunctionReflection<O, R> extends ElementReflection<O>
     }
     return cmp;
   }
+}
+
+extension _ObjectExtension on Object? {
+  bool get isAbsentParameterValue => this == absentParameterValue;
+
+  bool get isUnresolvedParameterValue => this == unresolvedParameterValue;
+
+  String get asStringSimple {
+    var val = this;
+
+    if (val.isPrimitiveValue) {
+      return '$val';
+    } else if (val is Iterable) {
+      return '(${val.runtimeType})[${val.map((e) => (e as Object?).asStringSimple).join(', ')}]';
+    } else if (val is Map) {
+      return '(${val.runtimeType}){${val.entries.map((e) => e.asStringSimple).join(', ')}}';
+    } else {
+      if (val is _UnresolvedParameterValue || val is _AbsentParameterValue) {
+        return '$val';
+      }
+      return '<Type:${val.runtimeType}>';
+    }
+  }
+}
+
+extension _MapEntryExtension<K, V> on MapEntry<K, V> {
+  String get asStringSimple => '$key=${value.asStringSimple}';
+}
+
+extension _IterableMapEntryExtension on Iterable<MapEntry> {
+  String get asStringSimple => '[${map((e) => e.asStringSimple).join(', ')}]';
 }
 
 typedef ConstructorReflectionAccessor = Function Function();
@@ -2904,12 +3030,14 @@ class MethodInvocation<T> {
   List<dynamic> get positionalArguments {
     var optionalParameters = this.optionalParameters;
 
-    return optionalParameters == null || optionalParameters.isEmpty
+    var args = optionalParameters == null || optionalParameters.isEmpty
         ? normalParameters
         : [
             ...normalParameters,
             ...optionalParameters,
           ];
+
+    return args;
   }
 
   /// The named arguments, derived from [namedParameters].
@@ -2921,7 +3049,9 @@ class MethodInvocation<T> {
     if (namedParameters == null || namedParameters.isEmpty) {
       return null;
     }
-    return namedParameters.map((key, value) => MapEntry(Symbol(key), value));
+    var args =
+        namedParameters.map((key, value) => MapEntry(Symbol(key), value));
+    return args;
   }
 
   /// Invokes the [Function] [f] with [positionalArguments] and [namedArguments].

--- a/lib/src/reflection_factory_base.dart
+++ b/lib/src/reflection_factory_base.dart
@@ -313,10 +313,8 @@ abstract class Reflection<O> {
     return null;
   }
 
-  /// Calls [function] with correct casting for [Reflection].
-  R callCasted<R>(R Function<O>(Reflection<O> reflection) function) {
-    return function<O>(this);
-  }
+  /// Calls [function] with correct casting for this [Reflection].
+  R callCasted<R>(R Function<O>(Reflection<O> reflection) function);
 
   /// Returns a [List] of siblings [Reflection] (declared in the same code unit).
   List<Reflection> siblingsReflection();

--- a/lib/src/reflection_factory_json.dart
+++ b/lib/src/reflection_factory_json.dart
@@ -1429,7 +1429,7 @@ class _JsonDecoder extends dart_convert.Converter<String, Object?>
         "Can't find registered JsonDecoder or Reflection for type: $type > $s");
   }
 
-  O _entityFromJsonValue<O>(
+  O? _entityFromJsonValue<O>(
       Type type, Object value, bool duplicatedEntitiesAsID) {
     if ((duplicatedEntitiesAsID || forceDuplicatedEntitiesAsID)) {
       var cachedEntity = entityCache.getCachedEntityByID(value, type: type);
@@ -1457,6 +1457,10 @@ class _JsonDecoder extends dart_convert.Converter<String, Object?>
         _cacheEntity(obj);
         return obj as O;
       }
+    }
+
+    if (value.runtimeType == type) {
+      return value as O;
     }
 
     if (!JsonConverter.isValidEntityType(type)) {
@@ -1511,7 +1515,7 @@ class _JsonDecoder extends dart_convert.Converter<String, Object?>
       }
     }
 
-    return value as O;
+    return null;
   }
 
   @override
@@ -1673,7 +1677,8 @@ class _JsonDecoder extends dart_convert.Converter<String, Object?>
         ReflectionFactory().getRegisterClassReflection(castType);
 
     if (classReflection != null) {
-      return classReflection.castList(val, castType) ?? val;
+      var nullable = val.any((e) => e == null);
+      return classReflection.castList(val, castType, nullable: nullable) ?? val;
     } else {
       return castListType(val, castType);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reflection_factory
 description: Allows Dart reflection with an easy approach, even for third-party classes, using code generation portable for all Dart platforms.
-version: 1.2.7
+version: 1.2.8
 homepage: https://github.com/gmpassos/reflection_factory
 
 environment:

--- a/test/reflection_factory_json_test.dart
+++ b/test/reflection_factory_json_test.dart
@@ -183,12 +183,14 @@ void main() {
           ),
           equals({'a': 1, 'b': 2, 'foo': '51:x'}));
 
-      expect(JsonCodec().toJson(TestAddressWithReflection('LA', 'Los Angeles')),
+      expect(
+          JsonCodec()
+              .toJson(TestAddressWithReflection('LA', city: 'Los Angeles')),
           equals({'state': 'LA', 'city': 'Los Angeles'}));
 
       expect(
           JsonCodec(removeField: (k) => k == 'city')
-              .toJson(TestAddressWithReflection('LA', 'Los Angeles')),
+              .toJson(TestAddressWithReflection('LA', city: 'Los Angeles')),
           equals({'state': 'LA'}));
 
       TestUserWithReflection$reflection();
@@ -228,11 +230,13 @@ void main() {
 
       expect(
           JsonCodec().toJson(TestCompanyWithReflection(
-              'FooInc', TestAddressWithReflection('State1', 'City1'), [
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
-          ])),
+              'FooInc', TestAddressWithReflection('State1', city: 'City1'),
+              extraAddresses: [
+                TestAddressWithReflection('State2', city: 'City2'),
+                TestAddressWithReflection('State3', city: 'City3')
+              ])),
           equals({
+            'branchesAddresses': [],
             'extraAddresses': [
               {'state': 'State2', 'city': 'City2'},
               {'state': 'State3', 'city': 'City3'}
@@ -243,8 +247,8 @@ void main() {
           }));
 
       expect(<dynamic>[
-        TestAddressWithReflection('State2', 'City2'),
-        TestAddressWithReflection('State3', 'City3')
+        TestAddressWithReflection('State2', city: 'City2'),
+        TestAddressWithReflection('State3', city: 'City3')
       ], isNot(isA<List<TestAddressWithReflection>>()));
 
       // List:
@@ -252,24 +256,24 @@ void main() {
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>[
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           ], TypeInfo.fromType(List, [TestAddressWithReflection])),
           isA<List<TestAddressWithReflection>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>[
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           ], TypeInfo.fromType(List, [Object])),
           isA<List<Object>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>[
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           ], TypeInfo.fromType(List, [dynamic])),
           isA<List<dynamic>>());
 
@@ -283,24 +287,24 @@ void main() {
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>[
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           ], TypeInfo.fromType(Iterable, [TestAddressWithReflection])),
           isA<Iterable<TestAddressWithReflection>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>[
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           ], TypeInfo.fromType(Iterable, [Object])),
           isA<Iterable<Object>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>[
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           ], TypeInfo.fromType(Iterable, [dynamic])),
           isA<Iterable<dynamic>>());
 
@@ -314,24 +318,24 @@ void main() {
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>{
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Set, [TestAddressWithReflection])),
           isA<Set<TestAddressWithReflection>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>{
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Set, [Object])),
           isA<Set<Object>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>{
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Set, [dynamic])),
           isA<Set<dynamic>>());
 
@@ -345,72 +349,72 @@ void main() {
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<Object, dynamic>{
-            'a': TestAddressWithReflection('State2', 'City2'),
-            'b': TestAddressWithReflection('State3', 'City3')
+            'a': TestAddressWithReflection('State2', city: 'City2'),
+            'b': TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Map, [String, TestAddressWithReflection])),
           isA<Map<String, TestAddressWithReflection>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<Object, dynamic>{
-            'a': TestAddressWithReflection('State2', 'City2'),
-            'b': TestAddressWithReflection('State3', 'City3')
+            'a': TestAddressWithReflection('State2', city: 'City2'),
+            'b': TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Map, [String, dynamic])),
           isA<Map<String, dynamic>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<Object, dynamic>{
-            'a': TestAddressWithReflection('State2', 'City2'),
-            'b': TestAddressWithReflection('State3', 'City3')
+            'a': TestAddressWithReflection('State2', city: 'City2'),
+            'b': TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Map, [String, Object])),
           isA<Map<String, Object>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<Object, dynamic>{
-            'a': TestAddressWithReflection('State2', 'City2'),
-            'b': TestAddressWithReflection('State3', 'City3')
+            'a': TestAddressWithReflection('State2', city: 'City2'),
+            'b': TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Map, [Object, TestAddressWithReflection])),
           isA<Map<Object, TestAddressWithReflection>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<Object, dynamic>{
-            'a': TestAddressWithReflection('State2', 'City2'),
-            'b': TestAddressWithReflection('State3', 'City3')
+            'a': TestAddressWithReflection('State2', city: 'City2'),
+            'b': TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Map, [Object, dynamic])),
           isA<Map<Object, dynamic>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<Object, dynamic>{
-            'a': TestAddressWithReflection('State2', 'City2'),
-            'b': TestAddressWithReflection('State3', 'City3')
+            'a': TestAddressWithReflection('State2', city: 'City2'),
+            'b': TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Map, [Object, Object])),
           isA<Map<Object, Object>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<Object, dynamic>{
-            'a': TestAddressWithReflection('State2', 'City2'),
-            'b': TestAddressWithReflection('State3', 'City3')
+            'a': TestAddressWithReflection('State2', city: 'City2'),
+            'b': TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Map, [dynamic, TestAddressWithReflection])),
           isA<Map<dynamic, TestAddressWithReflection>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<Object, dynamic>{
-            'a': TestAddressWithReflection('State2', 'City2'),
-            'b': TestAddressWithReflection('State3', 'City3')
+            'a': TestAddressWithReflection('State2', city: 'City2'),
+            'b': TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Map, [dynamic, Object])),
           isA<Map<dynamic, Object>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<Object, dynamic>{
-            'a': TestAddressWithReflection('State2', 'City2'),
-            'b': TestAddressWithReflection('State3', 'City3')
+            'a': TestAddressWithReflection('State2', city: 'City2'),
+            'b': TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Map, [dynamic, dynamic])),
           isA<Map<dynamic, dynamic>>());
 
@@ -456,20 +460,20 @@ void main() {
       expect(
           JsonCodec().fromJson({'state': 'LA', 'city': 'Los Angeles'},
               type: TestAddressWithReflection),
-          equals(TestAddressWithReflection('LA', 'Los Angeles')));
+          equals(TestAddressWithReflection('LA', city: 'Los Angeles')));
 
       expect(
           JsonCodec().fromJson({
             'city': 'Los Angeles',
             'state': 'LA',
           }, type: TestAddressWithReflection),
-          equals(TestAddressWithReflection('LA', 'Los Angeles')));
+          equals(TestAddressWithReflection('LA', city: 'Los Angeles')));
 
       expect(
           JsonCodec().fromJson({
             'state': 'LA',
           }, type: TestAddressWithReflection),
-          equals(TestAddressWithReflection('LA', '')));
+          equals(TestAddressWithReflection('LA')));
 
       expect(
           JsonCodec().fromJson({
@@ -482,10 +486,11 @@ void main() {
             'extraNames': ['BarInc', 'BazIn'],
           }, type: TestCompanyWithReflection),
           equals(TestCompanyWithReflection(
-              'FooInc', TestAddressWithReflection('State1', 'City1'), [
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
-          ],
+              'FooInc', TestAddressWithReflection('State1', city: 'City1'),
+              extraAddresses: [
+                TestAddressWithReflection('State2', city: 'City2'),
+                TestAddressWithReflection('State3', city: 'City3')
+              ],
               extraNames: [
                 'BarInc',
                 'BazIn'
@@ -501,10 +506,11 @@ void main() {
             'name': 'FooInc'
           }),
           equals(TestCompanyWithReflection(
-              'FooInc', TestAddressWithReflection('State1', 'City1'), [
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
-          ])));
+              'FooInc', TestAddressWithReflection('State1', city: 'City1'),
+              extraAddresses: [
+                TestAddressWithReflection('State2', city: 'City2'),
+                TestAddressWithReflection('State3', city: 'City3')
+              ])));
 
       expect(
           TestCompanyWithReflection$fromJson({
@@ -517,10 +523,11 @@ void main() {
             'name': 'FooInc'
           }),
           equals(TestCompanyWithReflection(
-              'FooInc', TestAddressWithReflection('State1', 'City1'), [
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
-          ],
+              'FooInc', TestAddressWithReflection('State1', city: 'City1'),
+              extraAddresses: [
+                TestAddressWithReflection('State2', city: 'City2'),
+                TestAddressWithReflection('State3', city: 'City3')
+              ],
               extraNames: [
                 'BarIn',
                 'BazInc'
@@ -538,31 +545,32 @@ void main() {
               }),
               type: TestCompanyWithReflection),
           equals(TestCompanyWithReflection(
-              'FooInc', TestAddressWithReflection('State1', 'City1'), [
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
-          ])));
+              'FooInc', TestAddressWithReflection('State1', city: 'City1'),
+              extraAddresses: [
+                TestAddressWithReflection('State2', city: 'City2'),
+                TestAddressWithReflection('State3', city: 'City3')
+              ])));
 
       expect(
           JsonCodec.defaultCodec.fromJsonList([
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           ], type: TestAddressWithReflection),
           equals([
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           ]));
 
       expect(
           await JsonCodec.defaultCodec.fromJsonListAsync(
               Future.value([
-                TestAddressWithReflection('State2', 'City2'),
-                TestAddressWithReflection('State3', 'City3')
+                TestAddressWithReflection('State2', city: 'City2'),
+                TestAddressWithReflection('State3', city: 'City3')
               ]),
               type: TestAddressWithReflection),
           equals([
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
+            TestAddressWithReflection('State2', city: 'City2'),
+            TestAddressWithReflection('State3', city: 'City3')
           ]));
 
       expect(
@@ -570,7 +578,7 @@ void main() {
               {'state': 'State1', 'city': 'City1'},
               type: TestAddressWithReflection),
           equals(
-            TestAddressWithReflection('State1', 'City1'),
+            TestAddressWithReflection('State1', city: 'City1'),
           ));
 
       expect(
@@ -578,7 +586,7 @@ void main() {
               Future.value({'state': 'State1', 'city': 'City1'}),
               type: TestAddressWithReflection),
           equals(
-            TestAddressWithReflection('State1', 'City1'),
+            TestAddressWithReflection('State1', city: 'City1'),
           ));
 
       expect(
@@ -586,7 +594,7 @@ void main() {
               {'state': 'State1', 'city': Future.value('City1')},
               type: TestAddressWithReflection),
           equals(
-            TestAddressWithReflection('State1', 'City1'),
+            TestAddressWithReflection('State1', city: 'City1'),
           ));
 
       expect(
@@ -594,20 +602,22 @@ void main() {
               '{"extraAddresses":[{"state":"State2","city":"City2"},{"state":"State3","city":"City3"}],"mainAddress":{"state":"State1","city":"City1"},"name":"FooInc"}',
               type: TestCompanyWithReflection),
           equals(TestCompanyWithReflection(
-              'FooInc', TestAddressWithReflection('State1', 'City1'), [
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
-          ])));
+              'FooInc', TestAddressWithReflection('State1', city: 'City1'),
+              extraAddresses: [
+                TestAddressWithReflection('State2', city: 'City2'),
+                TestAddressWithReflection('State3', city: 'City3')
+              ])));
 
       expect(
           TestCompanyWithReflection$fromJsonEncoded(
             '{"extraAddresses":[{"state":"State2","city":"City2"},{"state":"State3","city":"City3"}],"mainAddress":{"state":"State1","city":"City1"},"name":"FooInc"}',
           ),
           equals(TestCompanyWithReflection(
-              'FooInc', TestAddressWithReflection('State1', 'City1'), [
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
-          ])));
+              'FooInc', TestAddressWithReflection('State1', city: 'City1'),
+              extraAddresses: [
+                TestAddressWithReflection('State2', city: 'City2'),
+                TestAddressWithReflection('State3', city: 'City3')
+              ])));
 
       expect(
           TestDataWithReflection$fromJsonEncoded(
@@ -675,12 +685,13 @@ void main() {
 
       expect(
           JsonCodec().encode(TestCompanyWithReflection(
-              'FooInc', TestAddressWithReflection('State1', 'City1'), [
-            TestAddressWithReflection('State2', 'City2'),
-            TestAddressWithReflection('State3', 'City3')
-          ])),
+              'FooInc', TestAddressWithReflection('State1', city: 'City1'),
+              extraAddresses: [
+                TestAddressWithReflection('State2', city: 'City2'),
+                TestAddressWithReflection('State3', city: 'City3')
+              ])),
           equals(
-              '{"extraAddresses":[{"state":"State2","city":"City2"},{"state":"State3","city":"City3"}],"extraNames":[],"mainAddress":{"state":"State1","city":"City1"},"name":"FooInc"}'));
+              '{"branchesAddresses":[],"extraAddresses":[{"state":"State2","city":"City2"},{"state":"State3","city":"City3"}],"extraNames":[],"mainAddress":{"state":"State1","city":"City1"},"name":"FooInc"}'));
 
       expect(
           JsonCodec().encode(TestDataWithReflection(
@@ -764,7 +775,7 @@ void main() {
       expect(
           JsonCodec().decode('{"state":"State3","city":"City3"}',
               type: TestAddressWithReflection),
-          equals(TestAddressWithReflection('State3', 'City3')));
+          equals(TestAddressWithReflection('State3', city: 'City3')));
 
       expect(
           JsonCodec(jsomMapDecoderAsyncProvider: (type, map) {
@@ -778,7 +789,7 @@ void main() {
             };
           }).decodeAsync('{"state":"State4","city":"City4"}',
               type: TestAddressWithReflection),
-          equals(TestAddressWithReflection('STATE4', 'CITY4')));
+          equals(TestAddressWithReflection('STATE4', city: 'CITY4')));
     });
 
     test('encode/decode', () {
@@ -1055,7 +1066,26 @@ void main() {
 
         {
           var encodedJson = '{"amount":20,'
-              '"fromUser":404,'
+              '"toUser":1001,'
+              '"fromUser":{"axis":"x","email":"joe@mail.com","enabled":true,"id":1001,"isEnabled":true,"theLevel":null,"name":"joe","password":"123"}'
+              '}';
+
+          var decoded = jsonCodec.decode(encodedJson,
+              type: TestTransactionWithReflection,
+              duplicatedEntitiesAsID: true) as TestTransactionWithReflection;
+
+          print(decoded);
+
+          expect(decoded.fromUser, isA<TestUserWithReflection>());
+          expect(decoded.toUser, isA<TestUserWithReflection>());
+
+          expect(decoded.fromUser.id, equals(1001));
+          expect(decoded.toUser.id, equals(1001));
+        }
+
+        {
+          var encodedJson = '{"amount":"x",'
+              '"fromUser":1001,'
               '"toUser":{"axis":"x","email":"joe@mail.com","enabled":true,"id":1001,"isEnabled":true,"theLevel":null,"name":"joe","password":"123"}'
               '}';
 
@@ -1068,6 +1098,22 @@ void main() {
 
         {
           var encodedJson = '{"amount":20,'
+              '"fromUser":404,'
+              '"toUser":{"axis":"x","email":"joe@mail.com","enabled":true,"id":1001,"isEnabled":true,"theLevel":null,"name":"joe","password":"123"}'
+              '}';
+
+          expect(
+              () => jsonCodec.decode(encodedJson,
+                  type: TestTransactionWithReflection,
+                  duplicatedEntitiesAsID: true),
+              throwsA(isA<StateError>().having(
+                  (e) => e.message,
+                  'With unresolved_parameter',
+                  contains('<unresolved_parameter>'))));
+        }
+
+        {
+          var encodedJson = '{"amount":20,'
               '"fromUser":400,'
               '"toUser":404'
               '}';
@@ -1076,7 +1122,10 @@ void main() {
               () => jsonCodec.decode(encodedJson,
                   type: TestTransactionWithReflection,
                   duplicatedEntitiesAsID: true),
-              throwsA(isA<TypeError>()));
+              throwsA(isA<StateError>().having(
+                  (e) => e.message,
+                  'With unresolved_parameter',
+                  contains('<unresolved_parameter>'))));
         }
       }
     });

--- a/test/reflection_factory_json_test.dart
+++ b/test/reflection_factory_json_test.dart
@@ -262,12 +262,30 @@ void main() {
           isA<List<TestAddressWithReflection>>());
 
       expect(
+          TestAddressWithReflection$reflection.staticInstance.castCollection(
+              <dynamic>[
+                TestAddressWithReflection('State2', city: 'City2'),
+                null
+              ],
+              TypeInfo.fromType(List, [TestAddressWithReflection]),
+              nullable: true),
+          isA<List<TestAddressWithReflection?>>());
+
+      expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>[
             TestAddressWithReflection('State2', city: 'City2'),
             TestAddressWithReflection('State3', city: 'City3')
           ], TypeInfo.fromType(List, [Object])),
           isA<List<Object>>());
+
+      expect(
+          TestAddressWithReflection$reflection.staticInstance
+              .castCollection(<dynamic>[
+            TestAddressWithReflection('State2', city: 'City2'),
+            null
+          ], TypeInfo.fromType(List, [Object]), nullable: true),
+          isA<List<Object?>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
@@ -282,6 +300,12 @@ void main() {
               <dynamic>[123, 456], TypeInfo.fromType(List, [int])),
           isA<List<int>>());
 
+      expect(
+          TestAddressWithReflection$reflection.staticInstance.castCollection(
+              <dynamic>[123, null], TypeInfo.fromType(List, [int]),
+              nullable: true),
+          isA<List<int?>>());
+
       // Iterable:
 
       expect(
@@ -293,12 +317,30 @@ void main() {
           isA<Iterable<TestAddressWithReflection>>());
 
       expect(
+          TestAddressWithReflection$reflection.staticInstance.castCollection(
+              <dynamic>[
+                TestAddressWithReflection('State2', city: 'City2'),
+                null
+              ],
+              TypeInfo.fromType(Iterable, [TestAddressWithReflection]),
+              nullable: true),
+          isA<Iterable<TestAddressWithReflection?>>());
+
+      expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>[
             TestAddressWithReflection('State2', city: 'City2'),
             TestAddressWithReflection('State3', city: 'City3')
           ], TypeInfo.fromType(Iterable, [Object])),
           isA<Iterable<Object>>());
+
+      expect(
+          TestAddressWithReflection$reflection.staticInstance
+              .castCollection(<dynamic>[
+            TestAddressWithReflection('State2', city: 'City2'),
+            null
+          ], TypeInfo.fromType(Iterable, [Object]), nullable: true),
+          isA<Iterable<Object?>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
@@ -313,6 +355,12 @@ void main() {
               <dynamic>[123, 456], TypeInfo.fromType(Iterable, [int])),
           isA<Iterable<int>>());
 
+      expect(
+          TestAddressWithReflection$reflection.staticInstance.castCollection(
+              <dynamic>[123, null], TypeInfo.fromType(Iterable, [int]),
+              nullable: true),
+          isA<Iterable<int?>>());
+
       // Set:
 
       expect(
@@ -324,12 +372,30 @@ void main() {
           isA<Set<TestAddressWithReflection>>());
 
       expect(
+          TestAddressWithReflection$reflection.staticInstance.castCollection(
+              <dynamic>{
+                TestAddressWithReflection('State2', city: 'City2'),
+                null
+              },
+              TypeInfo.fromType(Set, [TestAddressWithReflection]),
+              nullable: true),
+          isA<Set<TestAddressWithReflection?>>());
+
+      expect(
           TestAddressWithReflection$reflection.staticInstance
               .castCollection(<dynamic>{
             TestAddressWithReflection('State2', city: 'City2'),
             TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Set, [Object])),
           isA<Set<Object>>());
+
+      expect(
+          TestAddressWithReflection$reflection.staticInstance
+              .castCollection(<dynamic>{
+            TestAddressWithReflection('State2', city: 'City2'),
+            null
+          }, TypeInfo.fromType(Set, [Object]), nullable: true),
+          isA<Set<Object?>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
@@ -344,6 +410,12 @@ void main() {
               <dynamic>{123, 456}, TypeInfo.fromType(Set, [int])),
           isA<Set<int>>());
 
+      expect(
+          TestAddressWithReflection$reflection.staticInstance.castCollection(
+              <dynamic>{123, null}, TypeInfo.fromType(Set, [int]),
+              nullable: true),
+          isA<Set<int?>>());
+
       // Map:
 
       expect(
@@ -353,6 +425,16 @@ void main() {
             'b': TestAddressWithReflection('State3', city: 'City3')
           }, TypeInfo.fromType(Map, [String, TestAddressWithReflection])),
           isA<Map<String, TestAddressWithReflection>>());
+
+      expect(
+          TestAddressWithReflection$reflection.staticInstance.castCollection(
+              <Object, dynamic>{
+                'a': TestAddressWithReflection('State2', city: 'City2'),
+                'b': null
+              },
+              TypeInfo.fromType(Map, [String, TestAddressWithReflection]),
+              nullable: true),
+          isA<Map<String, TestAddressWithReflection?>>());
 
       expect(
           TestAddressWithReflection$reflection.staticInstance
@@ -424,8 +506,25 @@ void main() {
               TypeInfo.fromType(Map, [String, int])),
           isA<Map<String, int>>());
 
+      expect(
+          TestAddressWithReflection$reflection.staticInstance.castCollection(
+              <Object, Object?>{'a': 123, 'b': null},
+              TypeInfo.fromType(Map, [String, int]),
+              nullable: true),
+          isA<Map<String, int?>>());
+
       expect(JsonCodec().toJson(TestOpAWithReflection(10)),
           equals({'type': 'a', 'value': 10}));
+
+      expect(
+          TestOpAWithReflection$reflection.staticInstance
+              .callCasted(<T>(c) => T),
+          equals(TestOpAWithReflection));
+
+      expect(
+          TestEnumWithReflection$reflection.staticInstance
+              .callCasted(<T>(c) => T),
+          equals(TestEnumWithReflection));
     });
 
     test('fromJson', () async {

--- a/test/reflection_factory_test.dart
+++ b/test/reflection_factory_test.dart
@@ -1074,16 +1074,14 @@ void main() {
       expect(userStaticReflection.getStaticField('version'), equals(1.1));
       expect(userStaticReflection.getStaticField('withReflection'), isTrue);
 
-      //TestAddressWithReflection$reflection.staticInstance;
-
-      var address = TestAddressWithReflection('CA', 'Los Angeles');
+      var address = TestAddressWithReflection('CA', city: 'Los Angeles');
       var addressReflection = address.reflection;
 
       expect(addressReflection, isNotNull);
       expect(addressReflection.hasJsonNameAlias, isFalse);
       expect(addressReflection.canCreateInstanceWithoutArguments, isTrue);
-      expect(
-          addressReflection.fieldsNames, equals(['city', 'hashCode', 'state']));
+      expect(addressReflection.fieldsNames,
+          equals(['city', 'hashCode', 'id', 'state']));
       expect(addressReflection.methodsNames, equals(['toJson']));
       expect(addressReflection.constructorsNames, equals(['', 'empty']));
 

--- a/test/src/reflection/user_with_reflection.g.dart
+++ b/test/src/reflection/user_with_reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.7
+// BUILDER: reflection_factory/1.2.8
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -112,7 +112,7 @@ class TestAddressWithReflection$reflection
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestAddressWithReflection$reflection withObject(
@@ -168,17 +168,19 @@ class TestAddressWithReflection$reflection
             this,
             TestAddressWithReflection,
             '',
-            () => (String state, [String city = '']) =>
-                TestAddressWithReflection(state, city),
+            () => (String state, {String city = '', int? id}) =>
+                TestAddressWithReflection(state, city: city, id: id),
             const <ParameterReflection>[
               ParameterReflection(
                   TypeReflection.tString, 'state', false, true, null, null)
             ],
-            const <ParameterReflection>[
-              ParameterReflection(
-                  TypeReflection.tString, 'city', false, false, '', null)
-            ],
             null,
+            const <String, ParameterReflection>{
+              'city': ParameterReflection(
+                  TypeReflection.tString, 'city', false, false, '', null),
+              'id': ParameterReflection(
+                  TypeReflection.tInt, 'id', true, false, null, null)
+            },
             null);
       case 'empty':
         return ConstructorReflection<TestAddressWithReflection>(
@@ -218,7 +220,8 @@ class TestAddressWithReflection$reflection
   }
 
   @override
-  List<String> get fieldsNames => const <String>['city', 'hashCode', 'state'];
+  List<String> get fieldsNames =>
+      const <String>['city', 'hashCode', 'id', 'state'];
 
   @override
   FieldReflection<TestAddressWithReflection, T>? field<T>(String fieldName,
@@ -228,6 +231,20 @@ class TestAddressWithReflection$reflection
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
+      case 'id':
+        return FieldReflection<TestAddressWithReflection, T>(
+          this,
+          TestAddressWithReflection,
+          TypeReflection.tInt,
+          'id',
+          true,
+          (o) => () => o!.id as T,
+          (o) => (T? v) => o!.id = v as int?,
+          obj,
+          false,
+          false,
+          null,
+        );
       case 'state':
         return FieldReflection<TestAddressWithReflection, T>(
           this,
@@ -343,7 +360,7 @@ class TestCompanyWithReflection$reflection
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestCompanyWithReflection$reflection withObject(
@@ -399,9 +416,14 @@ class TestCompanyWithReflection$reflection
             TestCompanyWithReflection,
             '',
             () => (String name, TestAddressWithReflection mainAddress,
-                    List<TestAddressWithReflection> extraAddresses,
-                    {List<String> extraNames = const <String>[]}) =>
-                TestCompanyWithReflection(name, mainAddress, extraAddresses,
+                    {List<TestAddressWithReflection> extraAddresses =
+                        const <TestAddressWithReflection>[],
+                    List<TestAddressWithReflection> branchesAddresses =
+                        const <TestAddressWithReflection>[],
+                    List<String> extraNames = const <String>[]}) =>
+                TestCompanyWithReflection(name, mainAddress,
+                    extraAddresses: extraAddresses,
+                    branchesAddresses: branchesAddresses,
                     extraNames: extraNames),
             const <ParameterReflection>[
               ParameterReflection(
@@ -413,8 +435,22 @@ class TestCompanyWithReflection$reflection
                   false,
                   true,
                   null,
+                  null)
+            ],
+            null,
+            const <String, ParameterReflection>{
+              'branchesAddresses': ParameterReflection(
+                  TypeReflection<List<TestAddressWithReflection>>(
+                      List, <TypeReflection>[
+                    TypeReflection<TestAddressWithReflection>(
+                        TestAddressWithReflection)
+                  ]),
+                  'branchesAddresses',
+                  false,
+                  false,
+                  const <TestAddressWithReflection>[],
                   null),
-              ParameterReflection(
+              'extraAddresses': ParameterReflection(
                   TypeReflection<List<TestAddressWithReflection>>(
                       List, <TypeReflection>[
                     TypeReflection<TestAddressWithReflection>(
@@ -422,12 +458,9 @@ class TestCompanyWithReflection$reflection
                   ]),
                   'extraAddresses',
                   false,
-                  true,
-                  null,
-                  null)
-            ],
-            null,
-            const <String, ParameterReflection>{
+                  false,
+                  const <TestAddressWithReflection>[],
+                  null),
               'extraNames': ParameterReflection(TypeReflection.tListString,
                   'extraNames', false, false, const <String>[], null)
             },
@@ -458,6 +491,7 @@ class TestCompanyWithReflection$reflection
 
   @override
   List<String> get fieldsNames => const <String>[
+        'branchesAddresses',
         'extraAddresses',
         'extraNames',
         'hashCode',
@@ -514,6 +548,24 @@ class TestCompanyWithReflection$reflection
           obj,
           false,
           true,
+          null,
+        );
+      case 'branchesaddresses':
+        return FieldReflection<TestCompanyWithReflection, T>(
+          this,
+          TestCompanyWithReflection,
+          TypeReflection<List<TestAddressWithReflection>>(
+              List, <TypeReflection>[
+            TypeReflection<TestAddressWithReflection>(TestAddressWithReflection)
+          ]),
+          'branchesAddresses',
+          false,
+          (o) => () => o!.branchesAddresses as T,
+          (o) => (T? v) =>
+              o!.branchesAddresses = v as List<TestAddressWithReflection>,
+          obj,
+          false,
+          false,
           null,
         );
       case 'extraaddresses':
@@ -616,7 +668,7 @@ class TestDataWithReflection$reflection
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestDataWithReflection$reflection withObject([TestDataWithReflection? obj]) =>
@@ -851,7 +903,7 @@ class TestDomainWithReflection$reflection
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestDomainWithReflection$reflection withObject(
@@ -1203,7 +1255,7 @@ class TestEnumWithReflection$reflection
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestEnumWithReflection$reflection withObject([TestEnumWithReflection? obj]) =>
@@ -1273,7 +1325,7 @@ class TestOpAWithReflection$reflection
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestOpAWithReflection$reflection withObject([TestOpAWithReflection? obj]) =>
@@ -1502,7 +1554,7 @@ class TestOpBWithReflection$reflection
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestOpBWithReflection$reflection withObject([TestOpBWithReflection? obj]) =>
@@ -1745,7 +1797,7 @@ class TestOpWithReflection$reflection
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestOpWithReflection$reflection withObject([TestOpWithReflection? obj]) =>
@@ -1995,7 +2047,7 @@ class TestTransactionWithReflection$reflection
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestTransactionWithReflection$reflection withObject(
@@ -2210,7 +2262,7 @@ class TestUserWithReflection$reflection
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestUserWithReflection$reflection withObject([TestUserWithReflection? obj]) =>

--- a/test/src/user_reflection_bridge.reflection.g.dart
+++ b/test/src/user_reflection_bridge.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.7
+// BUILDER: reflection_factory/1.2.8
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -41,7 +41,7 @@ class TestAddress$reflection extends ClassReflection<TestAddress> {
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestAddress$reflection withObject([TestAddress? obj]) =>
@@ -252,7 +252,7 @@ class TestUserSimple$reflection extends ClassReflection<TestUserSimple> {
   Version get languageVersion => Version.parse('2.17.0');
 
   @override
-  Version get reflectionFactoryVersion => Version.parse('1.2.7');
+  Version get reflectionFactoryVersion => Version.parse('1.2.8');
 
   @override
   TestUserSimple$reflection withObject([TestUserSimple? obj]) =>

--- a/test/src/user_with_reflection.dart
+++ b/test/src/user_with_reflection.dart
@@ -124,13 +124,15 @@ class TestUserWithReflection {
 
 @EnableReflection()
 class TestAddressWithReflection {
+  int? id;
+
   final String state;
 
   final String city;
 
-  TestAddressWithReflection(this.state, [this.city = '']);
+  TestAddressWithReflection(this.state, {this.city = '', this.id});
 
-  TestAddressWithReflection.empty() : this('', '');
+  TestAddressWithReflection.empty() : this('');
 
   @override
   bool operator ==(Object other) =>
@@ -144,7 +146,11 @@ class TestAddressWithReflection {
   int get hashCode => state.hashCode ^ city.hashCode;
 
   // Implements its own `toJson`:
-  Map<String, dynamic> toJson() => {'state': state, 'city': city};
+  Map<String, dynamic> toJson() => {
+        if (id != null) 'id': id,
+        'state': state,
+        'city': city,
+      };
 }
 
 @EnableReflection()
@@ -154,10 +160,14 @@ class TestCompanyWithReflection {
 
   final List<String> extraNames;
 
+  List<TestAddressWithReflection> branchesAddresses;
+
   List<TestAddressWithReflection> extraAddresses;
 
-  TestCompanyWithReflection(this.name, this.mainAddress, this.extraAddresses,
-      {this.extraNames = const <String>[]});
+  TestCompanyWithReflection(this.name, this.mainAddress,
+      {this.extraAddresses = const <TestAddressWithReflection>[],
+      this.branchesAddresses = const <TestAddressWithReflection>[],
+      this.extraNames = const <String>[]});
 
   @JsonField.hidden()
   bool local = false;
@@ -169,14 +179,17 @@ class TestCompanyWithReflection {
           runtimeType == other.runtimeType &&
           name == other.name &&
           mainAddress == other.mainAddress &&
+          ListEquality<String>().equals(extraNames, other.extraNames) &&
           ListEquality<TestAddressWithReflection>()
-              .equals(extraAddresses, other.extraAddresses) &&
-          ListEquality<String>().equals(extraNames, other.extraNames);
+              .equals(branchesAddresses, other.branchesAddresses) &&
+          ListEquality<TestAddressWithReflection>()
+              .equals(extraAddresses, other.extraAddresses);
 
   @override
   int get hashCode =>
       name.hashCode ^
       mainAddress.hashCode ^
+      ListEquality<TestAddressWithReflection>().hash(branchesAddresses) ^
       ListEquality<TestAddressWithReflection>().hash(extraAddresses) ^
       ListEquality<String>().hash(extraNames);
 }


### PR DESCRIPTION
- `FunctionReflection.methodInvocationFromMap` and `FunctionReflection.methodInvocation`:
  - Better handling of unresolved parameters values.
    Attempts to resolve 2 times, to allow entities references through cache.
- `Reflection`:
  - `castList`, `castSet`, `castIterable`, `castMap`, `castCollection`:
    - Added parameter `nullable`.
