### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 2.0.0
+
+- `ClassReflection`:
+  - `constructor`:
+    - removed `<R>` type.
+  - `field`:
+    - Ggenerated implementation declares `T` of `FieldReflection<$class,T>` statically.
+  - Optimized:
+    - `allFields`, `allMethods`: object instances derived from cached `no-object` instances.
+    - `construtor`, `staticField`, `field`, `method`:
+      - Caching instances.
+      - Object instances derived from cached `no-object` instances.
+- `FieldReflection`:
+  - Added `setNullable`.
+- benchmark: ^0.3.0
+  - `benchmark/reflection_factory_benchmark.dart`
+- meta: ^1.9.0
+
 ## 1.2.25
 
 - Extra fix: issue when a source has a `part of` directive.

--- a/benchmark/reflection_factory_benchmark.dart
+++ b/benchmark/reflection_factory_benchmark.dart
@@ -1,0 +1,53 @@
+import 'package:benchmark/benchmark.dart';
+import 'package:reflection_factory/builder.dart';
+import '../test/src/user_with_reflection.dart';
+
+void main() {
+  late ClassReflection<TestUserWithReflection> reflection;
+  late TestUserWithReflection user;
+  late ClassReflection<TestUserWithReflection> userReflection;
+
+  setUpEach(() {
+    reflection = TestUserWithReflection$reflection();
+    var c = reflection.constructor('fields');
+    user = c!.invoke(['Joe', 'joe@mail.com', 'pass123']);
+    userReflection = user.reflection;
+
+    reflection.staticField('version');
+    reflection.staticMethod('isVersion');
+    reflection.method('checkPassword');
+    reflection.field('name');
+  });
+
+  benchmark('reflection.constructor', () {
+    reflection.constructor('fields')!;
+  }, iterations: 1000000, duration: Duration(seconds: 5));
+
+  benchmark('userReflection.constructor', () {
+    userReflection.constructor('fields')!;
+  }, iterations: 1000000, duration: Duration(seconds: 5));
+
+  benchmark('reflection.staticField', () {
+    reflection.staticField('version')!;
+  }, iterations: 1000000, duration: Duration(seconds: 5));
+
+  benchmark('reflection.staticMethod', () {
+    reflection.staticMethod('isVersion')!;
+  }, iterations: 1000000, duration: Duration(seconds: 5));
+
+  benchmark('reflection.method', () {
+    userReflection.method('checkPassword')!;
+  }, iterations: 1000000, duration: Duration(seconds: 5));
+
+  benchmark('userReflection.method', () {
+    userReflection.method('checkPassword')!;
+  }, iterations: 1000000, duration: Duration(seconds: 5));
+
+  benchmark('reflection.field', () {
+    reflection.field('name')!;
+  }, iterations: 1000000, duration: Duration(seconds: 5));
+
+  benchmark('userReflection.field', () {
+    userReflection.field('name')!;
+  }, iterations: 1000000, duration: Duration(seconds: 5));
+}

--- a/example/reflection_factory_bridge_example.reflection.g.dart
+++ b/example/reflection_factory_bridge_example.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.25
+// BUILDER: reflection_factory/2.0.0
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('1.2.25');
+  static final Version _version = Version.parse('2.0.0');
 
   Version get reflectionFactoryVersion => _version;
 
@@ -85,8 +85,20 @@ class User$reflection extends ClassReflection<User> with __ReflectionMixin {
   @override
   List<String> get constructorsNames => const <String>['', 'empty'];
 
+  static final Map<String, ConstructorReflection<User>> _constructors =
+      <String, ConstructorReflection<User>>{};
+
   @override
-  ConstructorReflection<User>? constructor<R>(String constructorName) {
+  ConstructorReflection<User>? constructor(String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<User>? _constructorImpl(String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
     switch (lc) {
@@ -126,47 +138,89 @@ class User$reflection extends ClassReflection<User> with __ReflectionMixin {
   @override
   List<String> get fieldsNames => const <String>['email', 'hasEmail', 'pass'];
 
+  static final Map<String, FieldReflection<User, dynamic>> _fieldsNoObject =
+      <String, FieldReflection<User, dynamic>>{};
+
+  final Map<String, FieldReflection<User, dynamic>> _fieldsObject =
+      <String, FieldReflection<User, dynamic>>{};
+
   @override
   FieldReflection<User, T>? field<T>(String fieldName, [User? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<User, T>? _fieldNoObjectImpl<T>(String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<User, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<User, T>;
+  }
+
+  FieldReflection<User, T>? _fieldObjectImpl<T>(String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<User, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<User, dynamic>? _fieldImpl(String fieldName, User? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'email':
-        return FieldReflection<User, T>(
+        return FieldReflection<User, String?>(
           this,
           User,
           __TR.tString,
           'email',
           true,
-          (o) => () => o!.email as T,
-          (o) => (T? v) => o!.email = v as String?,
+          (o) => () => o!.email,
+          (o) => (v) => o!.email = v,
           obj,
           false,
           false,
         );
       case 'pass':
-        return FieldReflection<User, T>(
+        return FieldReflection<User, String>(
           this,
           User,
           __TR.tString,
           'pass',
           false,
-          (o) => () => o!.pass as T,
-          (o) => (T? v) => o!.pass = v as String,
+          (o) => () => o!.pass,
+          (o) => (v) => o!.pass = v,
           obj,
           false,
           false,
         );
       case 'hasemail':
-        return FieldReflection<User, T>(
+        return FieldReflection<User, bool>(
           this,
           User,
           __TR.tBool,
           'hasEmail',
           false,
-          (o) => () => o!.hasEmail as T,
+          (o) => () => o!.hasEmail,
           null,
           obj,
           false,
@@ -181,22 +235,62 @@ class User$reflection extends ClassReflection<User> with __ReflectionMixin {
   List<String> get staticFieldsNames => const <String>[];
 
   @override
-  FieldReflection<User, T>? staticField<T>(String fieldName) {
-    return null;
-  }
+  FieldReflection<User, T>? staticField<T>(String fieldName) => null;
 
   @override
   List<String> get methodsNames => const <String>['checkPassword'];
 
+  static final Map<String, MethodReflection<User, dynamic>> _methodsNoObject =
+      <String, MethodReflection<User, dynamic>>{};
+
+  final Map<String, MethodReflection<User, dynamic>> _methodsObject =
+      <String, MethodReflection<User, dynamic>>{};
+
   @override
   MethodReflection<User, R>? method<R>(String methodName, [User? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<User, R>? _methodNoObjectImpl<R>(String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<User, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<User, R>;
+  }
+
+  MethodReflection<User, R>? _methodObjectImpl<R>(String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<User, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<User, dynamic>? _methodImpl(String methodName, User? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'checkpassword':
-        return MethodReflection<User, R>(
+        return MethodReflection<User, bool>(
             this,
             User,
             'checkPassword',
@@ -218,9 +312,7 @@ class User$reflection extends ClassReflection<User> with __ReflectionMixin {
   List<String> get staticMethodsNames => const <String>[];
 
   @override
-  MethodReflection<User, R>? staticMethod<R>(String methodName) {
-    return null;
-  }
+  MethodReflection<User, R>? staticMethod<R>(String methodName) => null;
 }
 
 extension User$reflectionExtension on User {

--- a/example/reflection_factory_example.reflection.g.dart
+++ b/example/reflection_factory_example.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.25
+// BUILDER: reflection_factory/2.0.0
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('1.2.25');
+  static final Version _version = Version.parse('2.0.0');
 
   Version get reflectionFactoryVersion => _version;
 
@@ -85,8 +85,20 @@ class User$reflection extends ClassReflection<User> with __ReflectionMixin {
   @override
   List<String> get constructorsNames => const <String>['', 'empty'];
 
+  static final Map<String, ConstructorReflection<User>> _constructors =
+      <String, ConstructorReflection<User>>{};
+
   @override
-  ConstructorReflection<User>? constructor<R>(String constructorName) {
+  ConstructorReflection<User>? constructor(String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<User>? _constructorImpl(String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
     switch (lc) {
@@ -126,47 +138,89 @@ class User$reflection extends ClassReflection<User> with __ReflectionMixin {
   @override
   List<String> get fieldsNames => const <String>['email', 'hasEmail', 'pass'];
 
+  static final Map<String, FieldReflection<User, dynamic>> _fieldsNoObject =
+      <String, FieldReflection<User, dynamic>>{};
+
+  final Map<String, FieldReflection<User, dynamic>> _fieldsObject =
+      <String, FieldReflection<User, dynamic>>{};
+
   @override
   FieldReflection<User, T>? field<T>(String fieldName, [User? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<User, T>? _fieldNoObjectImpl<T>(String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<User, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<User, T>;
+  }
+
+  FieldReflection<User, T>? _fieldObjectImpl<T>(String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<User, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<User, dynamic>? _fieldImpl(String fieldName, User? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'email':
-        return FieldReflection<User, T>(
+        return FieldReflection<User, String?>(
           this,
           User,
           __TR.tString,
           'email',
           true,
-          (o) => () => o!.email as T,
-          (o) => (T? v) => o!.email = v as String?,
+          (o) => () => o!.email,
+          (o) => (v) => o!.email = v,
           obj,
           false,
           false,
         );
       case 'pass':
-        return FieldReflection<User, T>(
+        return FieldReflection<User, String>(
           this,
           User,
           __TR.tString,
           'pass',
           false,
-          (o) => () => o!.pass as T,
-          (o) => (T? v) => o!.pass = v as String,
+          (o) => () => o!.pass,
+          (o) => (v) => o!.pass = v,
           obj,
           false,
           false,
         );
       case 'hasemail':
-        return FieldReflection<User, T>(
+        return FieldReflection<User, bool>(
           this,
           User,
           __TR.tBool,
           'hasEmail',
           false,
-          (o) => () => o!.hasEmail as T,
+          (o) => () => o!.hasEmail,
           null,
           obj,
           false,
@@ -181,22 +235,62 @@ class User$reflection extends ClassReflection<User> with __ReflectionMixin {
   List<String> get staticFieldsNames => const <String>[];
 
   @override
-  FieldReflection<User, T>? staticField<T>(String fieldName) {
-    return null;
-  }
+  FieldReflection<User, T>? staticField<T>(String fieldName) => null;
 
   @override
   List<String> get methodsNames => const <String>['checkPassword'];
 
+  static final Map<String, MethodReflection<User, dynamic>> _methodsNoObject =
+      <String, MethodReflection<User, dynamic>>{};
+
+  final Map<String, MethodReflection<User, dynamic>> _methodsObject =
+      <String, MethodReflection<User, dynamic>>{};
+
   @override
   MethodReflection<User, R>? method<R>(String methodName, [User? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<User, R>? _methodNoObjectImpl<R>(String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<User, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<User, R>;
+  }
+
+  MethodReflection<User, R>? _methodObjectImpl<R>(String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<User, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<User, dynamic>? _methodImpl(String methodName, User? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'checkpassword':
-        return MethodReflection<User, R>(
+        return MethodReflection<User, bool>(
             this,
             User,
             'checkPassword',
@@ -218,9 +312,7 @@ class User$reflection extends ClassReflection<User> with __ReflectionMixin {
   List<String> get staticMethodsNames => const <String>[];
 
   @override
-  MethodReflection<User, R>? staticMethod<R>(String methodName) {
-    return null;
-  }
+  MethodReflection<User, R>? staticMethod<R>(String methodName) => null;
 }
 
 extension User$reflectionExtension on User {

--- a/lib/src/analyzer/reader.dart
+++ b/lib/src/analyzer/reader.dart
@@ -4,7 +4,6 @@
 
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:meta/meta.dart';
 
 import 'type_checker.dart';
 import 'utils.dart';
@@ -99,8 +98,7 @@ abstract class ConstantReader {
 }
 
 class _NullConstant extends ConstantReader {
-  @alwaysThrows
-  static T _throw<T>(String expected) {
+  static Never _throw<T>(String expected) {
     throw FormatException('Not an instance of $expected.');
   }
 

--- a/lib/src/reflection_factory_base.dart
+++ b/lib/src/reflection_factory_base.dart
@@ -1749,7 +1749,7 @@ abstract class ClassReflection<O> extends Reflection<O>
 
       if (key == null) {
         if (!field.isFinal && field.nullable) {
-          field.set(null);
+          field.setNullable(null);
         }
         continue;
       }
@@ -1771,7 +1771,7 @@ abstract class ClassReflection<O> extends Reflection<O>
         }
       } else if (field.nullable) {
         if (field.hasSetter) {
-          field.set(null);
+          field.setNullable(null);
         }
       }
     }

--- a/lib/src/reflection_factory_base.dart
+++ b/lib/src/reflection_factory_base.dart
@@ -2674,10 +2674,17 @@ class FieldReflection<O, T> extends ElementReflection<O>
     }
 
     if (setter != null) {
-      try {
-        setter(v as T);
-      } catch (e) {
-        throw ArgumentError("Field can't be null: $className.$name ($T)");
+      if (v == null) {
+        T vNull;
+        try {
+          vNull = null as T;
+        } catch (e) {
+          throw ArgumentError(
+              "Field can't be set to `null`: $className.$name ($T)");
+        }
+        setter(vNull);
+      } else {
+        setter(v);
       }
     } else {
       if (isFinal) {

--- a/lib/src/reflection_factory_base.dart
+++ b/lib/src/reflection_factory_base.dart
@@ -20,7 +20,7 @@ import 'reflection_factory_type.dart';
 /// Class with all registered reflections ([ClassReflection]).
 class ReflectionFactory {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.2.25';
+  static const String VERSION = '2.0.0';
 
   static final ReflectionFactory _instance = ReflectionFactory._();
 
@@ -903,7 +903,7 @@ abstract class ClassReflection<O> extends Reflection<O>
           constructorsNames.map((e) => constructor(e)!));
 
   /// Returns a [ConstructorReflection] for [constructorName].
-  ConstructorReflection<O>? constructor<R>(String constructorName);
+  ConstructorReflection<O>? constructor(String constructorName);
 
   /// Returns the best [ConstructorReflection] for [requiredParameters], [optionalParameters],
   /// [nullableParameters] and [presentParameters].
@@ -1086,14 +1086,35 @@ abstract class ClassReflection<O> extends Reflection<O>
 
   List<FieldReflection<O, dynamic>>? _allFieldsNoObject;
 
+  List<FieldReflection<O, dynamic>> _allFieldsNoObjectImpl() =>
+      _allFieldsNoObject ??= List<FieldReflection<O, dynamic>>.unmodifiable(
+          fieldsNames.map((e) => field(e)!));
+
+  List<FieldReflection<O, dynamic>>? _allFieldsObject;
+
+  List<FieldReflection<O, dynamic>> _allFieldsObjectImpl() {
+    final obj = object;
+    if (obj == null) {
+      throw StateError("Null `object`");
+    }
+    return _allFieldsObject ??= List<FieldReflection<O, dynamic>>.unmodifiable(
+        _allFieldsNoObjectImpl().map((e) => e.withObject(obj)));
+  }
+
   /// Returns a [List] with all fields [FieldReflection].
   List<FieldReflection<O, dynamic>> allFields([O? obj]) {
-    if (obj == null && object == null) {
-      _allFieldsNoObject ??= List<FieldReflection<O, dynamic>>.unmodifiable(
-          fieldsNames.map((e) => field(e, obj)!));
+    if (obj == null) {
+      if (object != null) {
+        return _allFieldsObjectImpl();
+      } else {
+        return _allFieldsNoObjectImpl();
+      }
+    } else if (identical(obj, object)) {
+      return _allFieldsObjectImpl();
     }
 
-    return fieldsNames.map((e) => field(e, obj)!).toList();
+    final o = obj;
+    return _allFieldsNoObjectImpl().map((f) => f.withObject(o)).toList();
   }
 
   bool? _hasFinalField;
@@ -1173,15 +1194,36 @@ abstract class ClassReflection<O> extends Reflection<O>
 
   List<MethodReflection<O, dynamic>>? _allMethodsNoObject;
 
+  List<MethodReflection<O, dynamic>> _allMethodsNoObjectImpl() =>
+      _allMethodsNoObject ??= List<MethodReflection<O, dynamic>>.unmodifiable(
+          methodsNames.map((e) => method(e)!));
+
+  List<MethodReflection<O, dynamic>>? _allMethodsObject;
+
+  List<MethodReflection<O, dynamic>> _allMethodsObjectImpl() {
+    final obj = object;
+    if (obj == null) {
+      throw StateError("Null `object`");
+    }
+    return _allMethodsObject ??=
+        List<MethodReflection<O, dynamic>>.unmodifiable(
+            _allMethodsNoObjectImpl().map((e) => e.withObject(obj)));
+  }
+
   /// Returns a [List] with all methods [MethodReflection].
   List<MethodReflection<O, dynamic>> allMethods([O? obj]) {
-    if (obj == null && object == null) {
-      return _allMethodsNoObject ??=
-          List<MethodReflection<O, dynamic>>.unmodifiable(
-              methodsNames.map((e) => method(e)!));
+    if (obj == null) {
+      if (object != null) {
+        return _allMethodsObjectImpl();
+      } else {
+        return _allMethodsNoObjectImpl();
+      }
+    } else if (identical(obj, object)) {
+      return _allMethodsObjectImpl();
     }
 
-    return methodsNames.map((e) => method(e, obj)!).toList();
+    final o = obj;
+    return _allMethodsNoObjectImpl().map((m) => m.withObject(o)).toList();
   }
 
   /// Returns a `const` [List] of static methods names.
@@ -2442,7 +2484,7 @@ class TypeReflection<T> {
 }
 
 typedef FieldGetter<T> = T Function();
-typedef FieldSetter<T> = void Function(T? v);
+typedef FieldSetter<T> = void Function(T v);
 
 typedef FieldReflectionGetterAccessor<O, T> = FieldGetter<T> Function(O? obj);
 typedef FieldReflectionSetterAccessor<O, T> = FieldSetter<T> Function(O? obj);
@@ -2604,7 +2646,8 @@ class FieldReflection<O, T> extends ElementReflection<O>
   bool get hasSetter => _setter != null || setterAccessor != null;
 
   /// Sets this field value.
-  void set(T? v) {
+  /// See [setNullable].
+  void set(T v) {
     var setter = _setter;
     if (setter == null && setterAccessor != null) {
       setter = _setter = setterAccessor!(object);
@@ -2617,6 +2660,30 @@ class FieldReflection<O, T> extends ElementReflection<O>
         throw StateError('Final field: $className.$name');
       } else {
         throw StateError('Field without setter: $className.$name');
+      }
+    }
+  }
+
+  /// Sets this field value, allowing a nullable value.
+  /// Throws an [ArgumentError] if [v] can't be `null`.
+  /// See [set].
+  void setNullable(T? v) {
+    var setter = _setter;
+    if (setter == null && setterAccessor != null) {
+      setter = _setter = setterAccessor!(object);
+    }
+
+    if (setter != null) {
+      try {
+        setter(v as T);
+      } catch (e) {
+        throw ArgumentError("Field can't be null: $className.$name ($T)");
+      }
+    } else {
+      if (isFinal) {
+        throw StateError('Final field: $className.$name ($T)');
+      } else {
+        throw StateError('Field without setter: $className.$name ($T)');
       }
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reflection_factory
 description: Allows Dart reflection with an easy approach, even for third-party classes, using code generation portable for all Dart platforms.
-version: 1.2.25
+version: 2.0.0
 homepage: https://github.com/gmpassos/reflection_factory
 
 environment:
@@ -10,7 +10,7 @@ dependencies:
   build: ^2.3.1
   analyzer: ^5.4.0
   dart_style: ^2.2.4
-  meta: ^1.8.0
+  meta: ^1.9.0
   mime: ^1.0.4
   base_codecs: ^1.0.1
   pub_semver: ^2.1.3
@@ -28,3 +28,4 @@ dev_dependencies:
   dependency_validator: ^3.2.2
   test: ^1.22.2
   coverage: ^1.6.2
+  benchmark: ^0.3.0

--- a/test/reflection_factory_test.dart
+++ b/test/reflection_factory_test.dart
@@ -606,6 +606,8 @@ void main() {
             TestOpAWithReflection,
             TestOpBWithReflection,
             TestTransactionWithReflection,
+            TestName,
+            TestEmpty,
           ]));
 
       expect(
@@ -614,16 +616,18 @@ void main() {
               .sorted()
               .map((e) => e.classType),
           equals([
+            TestEmpty,
             TestTransactionWithReflection,
             TestFranchiseWithReflection,
             TestDataWithReflection,
+            TestName,
             TestOpWithReflection,
             TestOpAWithReflection,
             TestAddressWithReflection,
             TestCompanyWithReflection,
             TestOpBWithReflection,
             TestDomainWithReflection,
-            TestUserWithReflection
+            TestUserWithReflection,
           ]));
 
       expect(
@@ -1329,6 +1333,18 @@ void main() {
 
       expect(ReflectionFactory.toJsonEncodable(address),
           equals({'state': 'CA', 'city': 'Los Angeles'}));
+
+      expect(TestEmpty$reflection().allFields(), isEmpty);
+      expect(TestEmpty$reflection().field('foo'), isNull);
+
+      expect(TestEmpty$reflection().allStaticFields(), isEmpty);
+      expect(TestEmpty$reflection().staticField('foo'), isNull);
+
+      expect(TestEmpty$reflection().allMethods(), isEmpty);
+      expect(TestEmpty$reflection().method('foo'), isNull);
+
+      expect(TestEmpty$reflection().allStaticMethods(), isEmpty);
+      expect(TestEmpty$reflection().staticMethod('foo'), isNull);
     });
 
     test('ReflectionBridge', () async {

--- a/test/src/reflection/user_with_reflection.g.dart
+++ b/test/src/reflection/user_with_reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.25
+// BUILDER: reflection_factory/2.0.0
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('1.2.25');
+  static final Version _version = Version.parse('2.0.0');
 
   Version get reflectionFactoryVersion => _version;
 
@@ -61,6 +61,12 @@ TestDomainWithReflection TestDomainWithReflection$fromJsonEncoded(
     TestDomainWithReflection$reflection.staticInstance
         .fromJsonEncoded(jsonEncoded);
 // ignore: non_constant_identifier_names
+TestEmpty TestEmpty$fromJson(Map<String, Object?> map) =>
+    TestEmpty$reflection.staticInstance.fromJson(map);
+// ignore: non_constant_identifier_names
+TestEmpty TestEmpty$fromJsonEncoded(String jsonEncoded) =>
+    TestEmpty$reflection.staticInstance.fromJsonEncoded(jsonEncoded);
+// ignore: non_constant_identifier_names
 TestEnumWithReflection? TestEnumWithReflection$from(Object? o) =>
     TestEnumWithReflection$reflection.staticInstance.from(o);
 // ignore: non_constant_identifier_names
@@ -72,6 +78,12 @@ TestFranchiseWithReflection TestFranchiseWithReflection$fromJsonEncoded(
         String jsonEncoded) =>
     TestFranchiseWithReflection$reflection.staticInstance
         .fromJsonEncoded(jsonEncoded);
+// ignore: non_constant_identifier_names
+TestName TestName$fromJson(Map<String, Object?> map) =>
+    TestName$reflection.staticInstance.fromJson(map);
+// ignore: non_constant_identifier_names
+TestName TestName$fromJsonEncoded(String jsonEncoded) =>
+    TestName$reflection.staticInstance.fromJsonEncoded(jsonEncoded);
 // ignore: non_constant_identifier_names
 TestOpAWithReflection TestOpAWithReflection$fromJson(
         Map<String, Object?> map) =>
@@ -176,8 +188,22 @@ class TestAddressWithReflection$reflection
   @override
   List<String> get constructorsNames => const <String>['', 'empty'];
 
+  static final Map<String, ConstructorReflection<TestAddressWithReflection>>
+      _constructors =
+      <String, ConstructorReflection<TestAddressWithReflection>>{};
+
   @override
-  ConstructorReflection<TestAddressWithReflection>? constructor<R>(
+  ConstructorReflection<TestAddressWithReflection>? constructor(
+      String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestAddressWithReflection>? _constructorImpl(
       String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
@@ -230,61 +256,108 @@ class TestAddressWithReflection$reflection
   List<String> get fieldsNames =>
       const <String>['city', 'hashCode', 'id', 'state'];
 
+  static final Map<String, FieldReflection<TestAddressWithReflection, dynamic>>
+      _fieldsNoObject =
+      <String, FieldReflection<TestAddressWithReflection, dynamic>>{};
+
+  final Map<String, FieldReflection<TestAddressWithReflection, dynamic>>
+      _fieldsObject =
+      <String, FieldReflection<TestAddressWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestAddressWithReflection, T>? field<T>(String fieldName,
       [TestAddressWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestAddressWithReflection, T>? _fieldNoObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestAddressWithReflection, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestAddressWithReflection, T>;
+  }
+
+  FieldReflection<TestAddressWithReflection, T>? _fieldObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestAddressWithReflection, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestAddressWithReflection, dynamic>? _fieldImpl(
+      String fieldName, TestAddressWithReflection? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'id':
-        return FieldReflection<TestAddressWithReflection, T>(
+        return FieldReflection<TestAddressWithReflection, int?>(
           this,
           TestAddressWithReflection,
           __TR.tInt,
           'id',
           true,
-          (o) => () => o!.id as T,
-          (o) => (T? v) => o!.id = v as int?,
+          (o) => () => o!.id,
+          (o) => (v) => o!.id = v,
           obj,
           false,
           false,
         );
       case 'state':
-        return FieldReflection<TestAddressWithReflection, T>(
+        return FieldReflection<TestAddressWithReflection, String>(
           this,
           TestAddressWithReflection,
           __TR.tString,
           'state',
           false,
-          (o) => () => o!.state as T,
+          (o) => () => o!.state,
           null,
           obj,
           false,
           true,
         );
       case 'city':
-        return FieldReflection<TestAddressWithReflection, T>(
+        return FieldReflection<TestAddressWithReflection, String>(
           this,
           TestAddressWithReflection,
           __TR.tString,
           'city',
           false,
-          (o) => () => o!.city as T,
+          (o) => () => o!.city,
           null,
           obj,
           false,
           true,
         );
       case 'hashcode':
-        return FieldReflection<TestAddressWithReflection, T>(
+        return FieldReflection<TestAddressWithReflection, int>(
           this,
           TestAddressWithReflection,
           __TR.tInt,
           'hashCode',
           false,
-          (o) => () => o!.hashCode as T,
+          (o) => () => o!.hashCode,
           null,
           obj,
           false,
@@ -301,23 +374,70 @@ class TestAddressWithReflection$reflection
 
   @override
   FieldReflection<TestAddressWithReflection, T>? staticField<T>(
-      String fieldName) {
-    return null;
-  }
+          String fieldName) =>
+      null;
 
   @override
   List<String> get methodsNames => const <String>['toJson', 'toString'];
 
+  static final Map<String, MethodReflection<TestAddressWithReflection, dynamic>>
+      _methodsNoObject =
+      <String, MethodReflection<TestAddressWithReflection, dynamic>>{};
+
+  final Map<String, MethodReflection<TestAddressWithReflection, dynamic>>
+      _methodsObject =
+      <String, MethodReflection<TestAddressWithReflection, dynamic>>{};
+
   @override
   MethodReflection<TestAddressWithReflection, R>? method<R>(String methodName,
       [TestAddressWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<TestAddressWithReflection, R>? _methodNoObjectImpl<R>(
+      String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestAddressWithReflection, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<TestAddressWithReflection, R>;
+  }
+
+  MethodReflection<TestAddressWithReflection, R>? _methodObjectImpl<R>(
+      String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestAddressWithReflection, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<TestAddressWithReflection, dynamic>? _methodImpl(
+      String methodName, TestAddressWithReflection? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'tojson':
-        return MethodReflection<TestAddressWithReflection, R>(
+        return MethodReflection<TestAddressWithReflection,
+                Map<String, dynamic>>(
             this,
             TestAddressWithReflection,
             'toJson',
@@ -331,7 +451,7 @@ class TestAddressWithReflection$reflection
             null,
             null);
       case 'tostring':
-        return MethodReflection<TestAddressWithReflection, R>(
+        return MethodReflection<TestAddressWithReflection, String>(
             this,
             TestAddressWithReflection,
             'toString',
@@ -354,9 +474,8 @@ class TestAddressWithReflection$reflection
 
   @override
   MethodReflection<TestAddressWithReflection, R>? staticMethod<R>(
-      String methodName) {
-    return null;
-  }
+          String methodName) =>
+      null;
 }
 
 class TestCompanyWithReflection$reflection
@@ -419,8 +538,22 @@ class TestCompanyWithReflection$reflection
   @override
   List<String> get constructorsNames => const <String>[''];
 
+  static final Map<String, ConstructorReflection<TestCompanyWithReflection>>
+      _constructors =
+      <String, ConstructorReflection<TestCompanyWithReflection>>{};
+
   @override
-  ConstructorReflection<TestCompanyWithReflection>? constructor<R>(
+  ConstructorReflection<TestCompanyWithReflection>? constructor(
+      String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestCompanyWithReflection>? _constructorImpl(
       String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
@@ -495,55 +628,104 @@ class TestCompanyWithReflection$reflection
         'name'
       ];
 
+  static final Map<String, FieldReflection<TestCompanyWithReflection, dynamic>>
+      _fieldsNoObject =
+      <String, FieldReflection<TestCompanyWithReflection, dynamic>>{};
+
+  final Map<String, FieldReflection<TestCompanyWithReflection, dynamic>>
+      _fieldsObject =
+      <String, FieldReflection<TestCompanyWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestCompanyWithReflection, T>? field<T>(String fieldName,
       [TestCompanyWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestCompanyWithReflection, T>? _fieldNoObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestCompanyWithReflection, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestCompanyWithReflection, T>;
+  }
+
+  FieldReflection<TestCompanyWithReflection, T>? _fieldObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestCompanyWithReflection, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestCompanyWithReflection, dynamic>? _fieldImpl(
+      String fieldName, TestCompanyWithReflection? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'name':
-        return FieldReflection<TestCompanyWithReflection, T>(
+        return FieldReflection<TestCompanyWithReflection, String>(
           this,
           TestCompanyWithReflection,
           __TR.tString,
           'name',
           false,
-          (o) => () => o!.name as T,
+          (o) => () => o!.name,
           null,
           obj,
           false,
           true,
         );
       case 'mainaddress':
-        return FieldReflection<TestCompanyWithReflection, T>(
+        return FieldReflection<TestCompanyWithReflection,
+            TestAddressWithReflection?>(
           this,
           TestCompanyWithReflection,
           __TR<TestAddressWithReflection>(TestAddressWithReflection),
           'mainAddress',
           true,
-          (o) => () => o!.mainAddress as T,
-          (o) => (T? v) => o!.mainAddress = v as TestAddressWithReflection?,
+          (o) => () => o!.mainAddress,
+          (o) => (v) => o!.mainAddress = v,
           obj,
           false,
           false,
         );
       case 'extranames':
-        return FieldReflection<TestCompanyWithReflection, T>(
+        return FieldReflection<TestCompanyWithReflection, List<String>>(
           this,
           TestCompanyWithReflection,
           __TR.tListString,
           'extraNames',
           false,
-          (o) => () => o!.extraNames as T,
+          (o) => () => o!.extraNames,
           null,
           obj,
           false,
           true,
         );
       case 'branchesaddresses':
-        return FieldReflection<TestCompanyWithReflection, T>(
+        return FieldReflection<TestCompanyWithReflection,
+            List<TestAddressWithReflection>>(
           this,
           TestCompanyWithReflection,
           __TR<List<TestAddressWithReflection>>(List, <__TR>[
@@ -551,15 +733,15 @@ class TestCompanyWithReflection$reflection
           ]),
           'branchesAddresses',
           false,
-          (o) => () => o!.branchesAddresses as T,
-          (o) => (T? v) =>
-              o!.branchesAddresses = v as List<TestAddressWithReflection>,
+          (o) => () => o!.branchesAddresses,
+          (o) => (v) => o!.branchesAddresses = v,
           obj,
           false,
           false,
         );
       case 'extraaddresses':
-        return FieldReflection<TestCompanyWithReflection, T>(
+        return FieldReflection<TestCompanyWithReflection,
+            List<TestAddressWithReflection>>(
           this,
           TestCompanyWithReflection,
           __TR<List<TestAddressWithReflection>>(List, <__TR>[
@@ -567,35 +749,34 @@ class TestCompanyWithReflection$reflection
           ]),
           'extraAddresses',
           false,
-          (o) => () => o!.extraAddresses as T,
-          (o) => (T? v) =>
-              o!.extraAddresses = v as List<TestAddressWithReflection>,
+          (o) => () => o!.extraAddresses,
+          (o) => (v) => o!.extraAddresses = v,
           obj,
           false,
           false,
         );
       case 'local':
-        return FieldReflection<TestCompanyWithReflection, T>(
+        return FieldReflection<TestCompanyWithReflection, bool>(
           this,
           TestCompanyWithReflection,
           __TR.tBool,
           'local',
           false,
-          (o) => () => o!.local as T,
-          (o) => (T? v) => o!.local = v as bool,
+          (o) => () => o!.local,
+          (o) => (v) => o!.local = v,
           obj,
           false,
           false,
           [JsonField.hidden()],
         );
       case 'hashcode':
-        return FieldReflection<TestCompanyWithReflection, T>(
+        return FieldReflection<TestCompanyWithReflection, int>(
           this,
           TestCompanyWithReflection,
           __TR.tInt,
           'hashCode',
           false,
-          (o) => () => o!.hashCode as T,
+          (o) => () => o!.hashCode,
           null,
           obj,
           false,
@@ -612,23 +793,69 @@ class TestCompanyWithReflection$reflection
 
   @override
   FieldReflection<TestCompanyWithReflection, T>? staticField<T>(
-      String fieldName) {
-    return null;
-  }
+          String fieldName) =>
+      null;
 
   @override
   List<String> get methodsNames => const <String>['toString'];
 
+  static final Map<String, MethodReflection<TestCompanyWithReflection, dynamic>>
+      _methodsNoObject =
+      <String, MethodReflection<TestCompanyWithReflection, dynamic>>{};
+
+  final Map<String, MethodReflection<TestCompanyWithReflection, dynamic>>
+      _methodsObject =
+      <String, MethodReflection<TestCompanyWithReflection, dynamic>>{};
+
   @override
   MethodReflection<TestCompanyWithReflection, R>? method<R>(String methodName,
       [TestCompanyWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<TestCompanyWithReflection, R>? _methodNoObjectImpl<R>(
+      String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestCompanyWithReflection, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<TestCompanyWithReflection, R>;
+  }
+
+  MethodReflection<TestCompanyWithReflection, R>? _methodObjectImpl<R>(
+      String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestCompanyWithReflection, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<TestCompanyWithReflection, dynamic>? _methodImpl(
+      String methodName, TestCompanyWithReflection? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'tostring':
-        return MethodReflection<TestCompanyWithReflection, R>(
+        return MethodReflection<TestCompanyWithReflection, String>(
             this,
             TestCompanyWithReflection,
             'toString',
@@ -651,9 +878,8 @@ class TestCompanyWithReflection$reflection
 
   @override
   MethodReflection<TestCompanyWithReflection, R>? staticMethod<R>(
-      String methodName) {
-    return null;
-  }
+          String methodName) =>
+      null;
 }
 
 class TestDataWithReflection$reflection
@@ -714,8 +940,21 @@ class TestDataWithReflection$reflection
   @override
   List<String> get constructorsNames => const <String>[''];
 
+  static final Map<String, ConstructorReflection<TestDataWithReflection>>
+      _constructors = <String, ConstructorReflection<TestDataWithReflection>>{};
+
   @override
-  ConstructorReflection<TestDataWithReflection>? constructor<R>(
+  ConstructorReflection<TestDataWithReflection>? constructor(
+      String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestDataWithReflection>? _constructorImpl(
       String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
@@ -763,74 +1002,122 @@ class TestDataWithReflection$reflection
   List<String> get fieldsNames =>
       const <String>['bytes', 'domain', 'hashCode', 'id', 'name'];
 
+  static final Map<String, FieldReflection<TestDataWithReflection, dynamic>>
+      _fieldsNoObject =
+      <String, FieldReflection<TestDataWithReflection, dynamic>>{};
+
+  final Map<String, FieldReflection<TestDataWithReflection, dynamic>>
+      _fieldsObject =
+      <String, FieldReflection<TestDataWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestDataWithReflection, T>? field<T>(String fieldName,
       [TestDataWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestDataWithReflection, T>? _fieldNoObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestDataWithReflection, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestDataWithReflection, T>;
+  }
+
+  FieldReflection<TestDataWithReflection, T>? _fieldObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestDataWithReflection, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestDataWithReflection, dynamic>? _fieldImpl(
+      String fieldName, TestDataWithReflection? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'name':
-        return FieldReflection<TestDataWithReflection, T>(
+        return FieldReflection<TestDataWithReflection, String>(
           this,
           TestDataWithReflection,
           __TR.tString,
           'name',
           false,
-          (o) => () => o!.name as T,
+          (o) => () => o!.name,
           null,
           obj,
           false,
           true,
         );
       case 'id':
-        return FieldReflection<TestDataWithReflection, T>(
+        return FieldReflection<TestDataWithReflection, BigInt>(
           this,
           TestDataWithReflection,
           __TR.tBigInt,
           'id',
           false,
-          (o) => () => o!.id as T,
-          (o) => (T? v) => o!.id = v as BigInt,
+          (o) => () => o!.id,
+          (o) => (v) => o!.id = v,
           obj,
           false,
           false,
         );
       case 'bytes':
-        return FieldReflection<TestDataWithReflection, T>(
+        return FieldReflection<TestDataWithReflection, Uint8List>(
           this,
           TestDataWithReflection,
           __TR<Uint8List>(Uint8List),
           'bytes',
           false,
-          (o) => () => o!.bytes as T,
-          (o) => (T? v) => o!.bytes = v as Uint8List,
+          (o) => () => o!.bytes,
+          (o) => (v) => o!.bytes = v,
           obj,
           false,
           false,
         );
       case 'domain':
-        return FieldReflection<TestDataWithReflection, T>(
+        return FieldReflection<TestDataWithReflection,
+            TestDomainWithReflection?>(
           this,
           TestDataWithReflection,
           __TR<TestDomainWithReflection>(TestDomainWithReflection),
           'domain',
           true,
-          (o) => () => o!.domain as T,
-          (o) => (T? v) => o!.domain = v as TestDomainWithReflection?,
+          (o) => () => o!.domain,
+          (o) => (v) => o!.domain = v,
           obj,
           false,
           false,
         );
       case 'hashcode':
-        return FieldReflection<TestDataWithReflection, T>(
+        return FieldReflection<TestDataWithReflection, int>(
           this,
           TestDataWithReflection,
           __TR.tInt,
           'hashCode',
           false,
-          (o) => () => o!.hashCode as T,
+          (o) => () => o!.hashCode,
           null,
           obj,
           false,
@@ -846,29 +1133,24 @@ class TestDataWithReflection$reflection
   List<String> get staticFieldsNames => const <String>[];
 
   @override
-  FieldReflection<TestDataWithReflection, T>? staticField<T>(String fieldName) {
-    return null;
-  }
+  FieldReflection<TestDataWithReflection, T>? staticField<T>(
+          String fieldName) =>
+      null;
 
   @override
   List<String> get methodsNames => const <String>[];
 
   @override
   MethodReflection<TestDataWithReflection, R>? method<R>(String methodName,
-      [TestDataWithReflection? obj]) {
-    obj ??= object;
-
-    return null;
-  }
-
+          [TestDataWithReflection? obj]) =>
+      null;
   @override
   List<String> get staticMethodsNames => const <String>[];
 
   @override
   MethodReflection<TestDataWithReflection, R>? staticMethod<R>(
-      String methodName) {
-    return null;
-  }
+          String methodName) =>
+      null;
 }
 
 class TestDomainWithReflection$reflection
@@ -931,8 +1213,22 @@ class TestDomainWithReflection$reflection
   @override
   List<String> get constructorsNames => const <String>['', 'named', 'parse'];
 
+  static final Map<String, ConstructorReflection<TestDomainWithReflection>>
+      _constructors =
+      <String, ConstructorReflection<TestDomainWithReflection>>{};
+
   @override
-  ConstructorReflection<TestDomainWithReflection>? constructor<R>(
+  ConstructorReflection<TestDomainWithReflection>? constructor(
+      String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestDomainWithReflection>? _constructorImpl(
       String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
@@ -1023,74 +1319,121 @@ class TestDomainWithReflection$reflection
         'suffix'
       ];
 
+  static final Map<String, FieldReflection<TestDomainWithReflection, dynamic>>
+      _fieldsNoObject =
+      <String, FieldReflection<TestDomainWithReflection, dynamic>>{};
+
+  final Map<String, FieldReflection<TestDomainWithReflection, dynamic>>
+      _fieldsObject =
+      <String, FieldReflection<TestDomainWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestDomainWithReflection, T>? field<T>(String fieldName,
       [TestDomainWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestDomainWithReflection, T>? _fieldNoObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestDomainWithReflection, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestDomainWithReflection, T>;
+  }
+
+  FieldReflection<TestDomainWithReflection, T>? _fieldObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestDomainWithReflection, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestDomainWithReflection, dynamic>? _fieldImpl(
+      String fieldName, TestDomainWithReflection? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'name':
-        return FieldReflection<TestDomainWithReflection, T>(
+        return FieldReflection<TestDomainWithReflection, String>(
           this,
           TestDomainWithReflection,
           __TR.tString,
           'name',
           false,
-          (o) => () => o!.name as T,
+          (o) => () => o!.name,
           null,
           obj,
           false,
           true,
         );
       case 'suffix':
-        return FieldReflection<TestDomainWithReflection, T>(
+        return FieldReflection<TestDomainWithReflection, String>(
           this,
           TestDomainWithReflection,
           __TR.tString,
           'suffix',
           false,
-          (o) => () => o!.suffix as T,
+          (o) => () => o!.suffix,
           null,
           obj,
           false,
           true,
         );
       case 'domainfunction':
-        return FieldReflection<TestDomainWithReflection, T>(
+        return FieldReflection<TestDomainWithReflection, DomainFunction?>(
           this,
           TestDomainWithReflection,
           __TR<DomainFunction>(DomainFunction),
           'domainFunction',
           true,
-          (o) => () => o!.domainFunction as T,
+          (o) => () => o!.domainFunction,
           null,
           obj,
           false,
           true,
         );
       case 'extrafunction':
-        return FieldReflection<TestDomainWithReflection, T>(
+        return FieldReflection<TestDomainWithReflection, bool Function()?>(
           this,
           TestDomainWithReflection,
           __TR.tFunction,
           'extraFunction',
           true,
-          (o) => () => o!.extraFunction as T,
+          (o) => () => o!.extraFunction,
           null,
           obj,
           false,
           true,
         );
       case 'hashcode':
-        return FieldReflection<TestDomainWithReflection, T>(
+        return FieldReflection<TestDomainWithReflection, int>(
           this,
           TestDomainWithReflection,
           __TR.tInt,
           'hashCode',
           false,
-          (o) => () => o!.hashCode as T,
+          (o) => () => o!.hashCode,
           null,
           obj,
           false,
@@ -1107,24 +1450,70 @@ class TestDomainWithReflection$reflection
 
   @override
   FieldReflection<TestDomainWithReflection, T>? staticField<T>(
-      String fieldName) {
-    return null;
-  }
+          String fieldName) =>
+      null;
 
   @override
   List<String> get methodsNames =>
       const <String>['toJson', 'toString', 'typedFunction'];
 
+  static final Map<String, MethodReflection<TestDomainWithReflection, dynamic>>
+      _methodsNoObject =
+      <String, MethodReflection<TestDomainWithReflection, dynamic>>{};
+
+  final Map<String, MethodReflection<TestDomainWithReflection, dynamic>>
+      _methodsObject =
+      <String, MethodReflection<TestDomainWithReflection, dynamic>>{};
+
   @override
   MethodReflection<TestDomainWithReflection, R>? method<R>(String methodName,
       [TestDomainWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<TestDomainWithReflection, R>? _methodNoObjectImpl<R>(
+      String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestDomainWithReflection, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<TestDomainWithReflection, R>;
+  }
+
+  MethodReflection<TestDomainWithReflection, R>? _methodObjectImpl<R>(
+      String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestDomainWithReflection, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<TestDomainWithReflection, dynamic>? _methodImpl(
+      String methodName, TestDomainWithReflection? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'typedfunction':
-        return MethodReflection<TestDomainWithReflection, R>(
+        return MethodReflection<TestDomainWithReflection, bool>(
             this,
             TestDomainWithReflection,
             'typedFunction',
@@ -1146,7 +1535,7 @@ class TestDomainWithReflection$reflection
             null,
             null);
       case 'tojson':
-        return MethodReflection<TestDomainWithReflection, R>(
+        return MethodReflection<TestDomainWithReflection, String>(
             this,
             TestDomainWithReflection,
             'toJson',
@@ -1160,7 +1549,7 @@ class TestDomainWithReflection$reflection
             null,
             null);
       case 'tostring':
-        return MethodReflection<TestDomainWithReflection, R>(
+        return MethodReflection<TestDomainWithReflection, String>(
             this,
             TestDomainWithReflection,
             'toString',
@@ -1183,9 +1572,128 @@ class TestDomainWithReflection$reflection
 
   @override
   MethodReflection<TestDomainWithReflection, R>? staticMethod<R>(
-      String methodName) {
-    return null;
+          String methodName) =>
+      null;
+}
+
+class TestEmpty$reflection extends ClassReflection<TestEmpty>
+    with __ReflectionMixin {
+  TestEmpty$reflection([TestEmpty? object])
+      : super(TestEmpty, 'TestEmpty', object);
+
+  static bool _registered = false;
+  @override
+  void register() {
+    if (!_registered) {
+      _registered = true;
+      super.register();
+      _registerSiblingsReflection();
+    }
   }
+
+  @override
+  Version get languageVersion => Version.parse('2.17.0');
+
+  @override
+  TestEmpty$reflection withObject([TestEmpty? obj]) =>
+      TestEmpty$reflection(obj);
+
+  static TestEmpty$reflection? _withoutObjectInstance;
+  @override
+  TestEmpty$reflection withoutObjectInstance() => _withoutObjectInstance ??=
+      super.withoutObjectInstance() as TestEmpty$reflection;
+
+  static TestEmpty$reflection get staticInstance =>
+      _withoutObjectInstance ??= TestEmpty$reflection();
+
+  @override
+  TestEmpty$reflection getStaticInstance() => staticInstance;
+
+  static bool _boot = false;
+  static void boot() {
+    if (_boot) return;
+    _boot = true;
+    TestEmpty$reflection.staticInstance;
+  }
+
+  @override
+  bool get hasDefaultConstructor => true;
+  @override
+  TestEmpty? createInstanceWithDefaultConstructor() => TestEmpty();
+
+  @override
+  bool get hasEmptyConstructor => false;
+  @override
+  TestEmpty? createInstanceWithEmptyConstructor() => null;
+  @override
+  bool get hasNoRequiredArgsConstructor => false;
+  @override
+  TestEmpty? createInstanceWithNoRequiredArgsConstructor() => null;
+
+  @override
+  List<String> get constructorsNames => const <String>[''];
+
+  static final Map<String, ConstructorReflection<TestEmpty>> _constructors =
+      <String, ConstructorReflection<TestEmpty>>{};
+
+  @override
+  ConstructorReflection<TestEmpty>? constructor(String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestEmpty>? _constructorImpl(String constructorName) {
+    var lc = constructorName.trim().toLowerCase();
+
+    switch (lc) {
+      case '':
+        return ConstructorReflection<TestEmpty>(this, TestEmpty, '',
+            () => () => TestEmpty(), null, null, null, null);
+      default:
+        return null;
+    }
+  }
+
+  @override
+  List<Object> get classAnnotations => List<Object>.unmodifiable(<Object>[]);
+
+  @override
+  List<Type> get supperTypes => const <Type>[];
+
+  @override
+  bool get hasMethodToJson => false;
+
+  @override
+  Object? callMethodToJson([TestEmpty? obj]) => null;
+
+  @override
+  List<String> get fieldsNames => const <String>[];
+
+  @override
+  FieldReflection<TestEmpty, T>? field<T>(String fieldName, [TestEmpty? obj]) =>
+      null;
+  @override
+  List<String> get staticFieldsNames => const <String>[];
+
+  @override
+  FieldReflection<TestEmpty, T>? staticField<T>(String fieldName) => null;
+
+  @override
+  List<String> get methodsNames => const <String>[];
+
+  @override
+  MethodReflection<TestEmpty, R>? method<R>(String methodName,
+          [TestEmpty? obj]) =>
+      null;
+  @override
+  List<String> get staticMethodsNames => const <String>[];
+
+  @override
+  MethodReflection<TestEmpty, R>? staticMethod<R>(String methodName) => null;
 }
 
 class TestEnumWithReflection$reflection
@@ -1310,8 +1818,22 @@ class TestFranchiseWithReflection$reflection
   @override
   List<String> get constructorsNames => const <String>[''];
 
+  static final Map<String, ConstructorReflection<TestFranchiseWithReflection>>
+      _constructors =
+      <String, ConstructorReflection<TestFranchiseWithReflection>>{};
+
   @override
-  ConstructorReflection<TestFranchiseWithReflection>? constructor<R>(
+  ConstructorReflection<TestFranchiseWithReflection>? constructor(
+      String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestFranchiseWithReflection>? _constructorImpl(
       String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
@@ -1359,29 +1881,78 @@ class TestFranchiseWithReflection$reflection
   List<String> get fieldsNames =>
       const <String>['addresses', 'hashCode', 'name'];
 
+  static final Map<String,
+          FieldReflection<TestFranchiseWithReflection, dynamic>>
+      _fieldsNoObject =
+      <String, FieldReflection<TestFranchiseWithReflection, dynamic>>{};
+
+  final Map<String, FieldReflection<TestFranchiseWithReflection, dynamic>>
+      _fieldsObject =
+      <String, FieldReflection<TestFranchiseWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestFranchiseWithReflection, T>? field<T>(String fieldName,
       [TestFranchiseWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestFranchiseWithReflection, T>? _fieldNoObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestFranchiseWithReflection, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestFranchiseWithReflection, T>;
+  }
+
+  FieldReflection<TestFranchiseWithReflection, T>? _fieldObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestFranchiseWithReflection, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestFranchiseWithReflection, dynamic>? _fieldImpl(
+      String fieldName, TestFranchiseWithReflection? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'name':
-        return FieldReflection<TestFranchiseWithReflection, T>(
+        return FieldReflection<TestFranchiseWithReflection, String>(
           this,
           TestFranchiseWithReflection,
           __TR.tString,
           'name',
           false,
-          (o) => () => o!.name as T,
+          (o) => () => o!.name,
           null,
           obj,
           false,
           true,
         );
       case 'addresses':
-        return FieldReflection<TestFranchiseWithReflection, T>(
+        return FieldReflection<TestFranchiseWithReflection,
+            Map<String, TestAddressWithReflection>>(
           this,
           TestFranchiseWithReflection,
           __TR<Map<String, TestAddressWithReflection>>(Map, <__TR>[
@@ -1390,21 +1961,20 @@ class TestFranchiseWithReflection$reflection
           ]),
           'addresses',
           false,
-          (o) => () => o!.addresses as T,
-          (o) => (T? v) =>
-              o!.addresses = v as Map<String, TestAddressWithReflection>,
+          (o) => () => o!.addresses,
+          (o) => (v) => o!.addresses = v,
           obj,
           false,
           false,
         );
       case 'hashcode':
-        return FieldReflection<TestFranchiseWithReflection, T>(
+        return FieldReflection<TestFranchiseWithReflection, int>(
           this,
           TestFranchiseWithReflection,
           __TR.tInt,
           'hashCode',
           false,
-          (o) => () => o!.hashCode as T,
+          (o) => () => o!.hashCode,
           null,
           obj,
           false,
@@ -1421,23 +1991,70 @@ class TestFranchiseWithReflection$reflection
 
   @override
   FieldReflection<TestFranchiseWithReflection, T>? staticField<T>(
-      String fieldName) {
-    return null;
-  }
+          String fieldName) =>
+      null;
 
   @override
   List<String> get methodsNames => const <String>['toString'];
 
+  static final Map<String,
+          MethodReflection<TestFranchiseWithReflection, dynamic>>
+      _methodsNoObject =
+      <String, MethodReflection<TestFranchiseWithReflection, dynamic>>{};
+
+  final Map<String, MethodReflection<TestFranchiseWithReflection, dynamic>>
+      _methodsObject =
+      <String, MethodReflection<TestFranchiseWithReflection, dynamic>>{};
+
   @override
   MethodReflection<TestFranchiseWithReflection, R>? method<R>(String methodName,
       [TestFranchiseWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<TestFranchiseWithReflection, R>? _methodNoObjectImpl<R>(
+      String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestFranchiseWithReflection, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<TestFranchiseWithReflection, R>;
+  }
+
+  MethodReflection<TestFranchiseWithReflection, R>? _methodObjectImpl<R>(
+      String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestFranchiseWithReflection, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<TestFranchiseWithReflection, dynamic>? _methodImpl(
+      String methodName, TestFranchiseWithReflection? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'tostring':
-        return MethodReflection<TestFranchiseWithReflection, R>(
+        return MethodReflection<TestFranchiseWithReflection, String>(
             this,
             TestFranchiseWithReflection,
             'toString',
@@ -1460,9 +2077,283 @@ class TestFranchiseWithReflection$reflection
 
   @override
   MethodReflection<TestFranchiseWithReflection, R>? staticMethod<R>(
-      String methodName) {
-    return null;
+          String methodName) =>
+      null;
+}
+
+class TestName$reflection extends ClassReflection<TestName>
+    with __ReflectionMixin {
+  TestName$reflection([TestName? object]) : super(TestName, 'TestName', object);
+
+  static bool _registered = false;
+  @override
+  void register() {
+    if (!_registered) {
+      _registered = true;
+      super.register();
+      _registerSiblingsReflection();
+    }
   }
+
+  @override
+  Version get languageVersion => Version.parse('2.17.0');
+
+  @override
+  TestName$reflection withObject([TestName? obj]) => TestName$reflection(obj);
+
+  static TestName$reflection? _withoutObjectInstance;
+  @override
+  TestName$reflection withoutObjectInstance() => _withoutObjectInstance ??=
+      super.withoutObjectInstance() as TestName$reflection;
+
+  static TestName$reflection get staticInstance =>
+      _withoutObjectInstance ??= TestName$reflection();
+
+  @override
+  TestName$reflection getStaticInstance() => staticInstance;
+
+  static bool _boot = false;
+  static void boot() {
+    if (_boot) return;
+    _boot = true;
+    TestName$reflection.staticInstance;
+  }
+
+  @override
+  bool get hasDefaultConstructor => true;
+  @override
+  TestName? createInstanceWithDefaultConstructor() => TestName();
+
+  @override
+  bool get hasEmptyConstructor => false;
+  @override
+  TestName? createInstanceWithEmptyConstructor() => null;
+  @override
+  bool get hasNoRequiredArgsConstructor => false;
+  @override
+  TestName? createInstanceWithNoRequiredArgsConstructor() => null;
+
+  @override
+  List<String> get constructorsNames => const <String>[''];
+
+  static final Map<String, ConstructorReflection<TestName>> _constructors =
+      <String, ConstructorReflection<TestName>>{};
+
+  @override
+  ConstructorReflection<TestName>? constructor(String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestName>? _constructorImpl(String constructorName) {
+    var lc = constructorName.trim().toLowerCase();
+
+    switch (lc) {
+      case '':
+        return ConstructorReflection<TestName>(
+            this, TestName, '', () => () => TestName(), null, null, null, null);
+      default:
+        return null;
+    }
+  }
+
+  @override
+  List<Object> get classAnnotations => List<Object>.unmodifiable(<Object>[]);
+
+  @override
+  List<Type> get supperTypes => const <Type>[];
+
+  @override
+  bool get hasMethodToJson => false;
+
+  @override
+  Object? callMethodToJson([TestName? obj]) => null;
+
+  @override
+  List<String> get fieldsNames => const <String>['isEmpty', 'name'];
+
+  static final Map<String, FieldReflection<TestName, dynamic>> _fieldsNoObject =
+      <String, FieldReflection<TestName, dynamic>>{};
+
+  final Map<String, FieldReflection<TestName, dynamic>> _fieldsObject =
+      <String, FieldReflection<TestName, dynamic>>{};
+
+  @override
+  FieldReflection<TestName, T>? field<T>(String fieldName, [TestName? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestName, T>? _fieldNoObjectImpl<T>(String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestName, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestName, T>;
+  }
+
+  FieldReflection<TestName, T>? _fieldObjectImpl<T>(String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestName, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestName, dynamic>? _fieldImpl(
+      String fieldName, TestName? obj) {
+    obj ??= object;
+
+    var lc = fieldName.trim().toLowerCase();
+
+    switch (lc) {
+      case 'name':
+        return FieldReflection<TestName, String?>(
+          this,
+          TestName,
+          __TR.tString,
+          'name',
+          true,
+          (o) => () => o!.name,
+          (o) => (v) => o!.name = v,
+          obj,
+          false,
+          false,
+        );
+      case 'isempty':
+        return FieldReflection<TestName, bool>(
+          this,
+          TestName,
+          __TR.tBool,
+          'isEmpty',
+          false,
+          (o) => () => o!.isEmpty,
+          null,
+          obj,
+          false,
+          false,
+        );
+      default:
+        return null;
+    }
+  }
+
+  @override
+  List<String> get staticFieldsNames => const <String>[];
+
+  @override
+  FieldReflection<TestName, T>? staticField<T>(String fieldName) => null;
+
+  @override
+  List<String> get methodsNames => const <String>['nameNormalized', 'toString'];
+
+  static final Map<String, MethodReflection<TestName, dynamic>>
+      _methodsNoObject = <String, MethodReflection<TestName, dynamic>>{};
+
+  final Map<String, MethodReflection<TestName, dynamic>> _methodsObject =
+      <String, MethodReflection<TestName, dynamic>>{};
+
+  @override
+  MethodReflection<TestName, R>? method<R>(String methodName, [TestName? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<TestName, R>? _methodNoObjectImpl<R>(String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestName, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<TestName, R>;
+  }
+
+  MethodReflection<TestName, R>? _methodObjectImpl<R>(String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestName, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<TestName, dynamic>? _methodImpl(
+      String methodName, TestName? obj) {
+    obj ??= object;
+
+    var lc = methodName.trim().toLowerCase();
+
+    switch (lc) {
+      case 'namenormalized':
+        return MethodReflection<TestName, String>(
+            this,
+            TestName,
+            'nameNormalized',
+            __TR.tString,
+            false,
+            (o) => o!.nameNormalized,
+            obj,
+            false,
+            null,
+            null,
+            null,
+            null);
+      case 'tostring':
+        return MethodReflection<TestName, String>(
+            this,
+            TestName,
+            'toString',
+            __TR.tString,
+            false,
+            (o) => o!.toString,
+            obj,
+            false,
+            null,
+            null,
+            null,
+            [override]);
+      default:
+        return null;
+    }
+  }
+
+  @override
+  List<String> get staticMethodsNames => const <String>[];
+
+  @override
+  MethodReflection<TestName, R>? staticMethod<R>(String methodName) => null;
 }
 
 class TestOpAWithReflection$reflection
@@ -1523,8 +2414,21 @@ class TestOpAWithReflection$reflection
   @override
   List<String> get constructorsNames => const <String>[''];
 
+  static final Map<String, ConstructorReflection<TestOpAWithReflection>>
+      _constructors = <String, ConstructorReflection<TestOpAWithReflection>>{};
+
   @override
-  ConstructorReflection<TestOpAWithReflection>? constructor<R>(
+  ConstructorReflection<TestOpAWithReflection>? constructor(
+      String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestOpAWithReflection>? _constructorImpl(
       String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
@@ -1559,36 +2463,83 @@ class TestOpAWithReflection$reflection
   @override
   List<String> get fieldsNames => const <String>['type', 'value'];
 
+  static final Map<String, FieldReflection<TestOpAWithReflection, dynamic>>
+      _fieldsNoObject =
+      <String, FieldReflection<TestOpAWithReflection, dynamic>>{};
+
+  final Map<String, FieldReflection<TestOpAWithReflection, dynamic>>
+      _fieldsObject =
+      <String, FieldReflection<TestOpAWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestOpAWithReflection, T>? field<T>(String fieldName,
       [TestOpAWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestOpAWithReflection, T>? _fieldNoObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestOpAWithReflection, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestOpAWithReflection, T>;
+  }
+
+  FieldReflection<TestOpAWithReflection, T>? _fieldObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestOpAWithReflection, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestOpAWithReflection, dynamic>? _fieldImpl(
+      String fieldName, TestOpAWithReflection? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'value':
-        return FieldReflection<TestOpAWithReflection, T>(
+        return FieldReflection<TestOpAWithReflection, int>(
           this,
           TestOpAWithReflection,
           __TR.tInt,
           'value',
           false,
-          (o) => () => o!.value as T,
-          (o) => (T? v) => o!.value = v as int,
+          (o) => () => o!.value,
+          (o) => (v) => o!.value = v,
           obj,
           false,
           false,
           [override, override],
         );
       case 'type':
-        return FieldReflection<TestOpAWithReflection, T>(
+        return FieldReflection<TestOpAWithReflection, String>(
           this,
           TestOpWithReflection,
           __TR.tString,
           'type',
           false,
-          (o) => () => o!.type as T,
+          (o) => () => o!.type,
           null,
           obj,
           false,
@@ -1602,20 +2553,36 @@ class TestOpAWithReflection$reflection
   @override
   List<String> get staticFieldsNames => const <String>['staticFieldA'];
 
+  static final Map<String, FieldReflection<TestOpAWithReflection, dynamic>>
+      _staticFields =
+      <String, FieldReflection<TestOpAWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestOpAWithReflection, T>? staticField<T>(String fieldName) {
+    var f = _staticFields[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestOpAWithReflection, T>;
+    }
+    f = _staticFieldImpl(fieldName);
+    if (f == null) return null;
+    _staticFields[fieldName] = f;
+    return f as FieldReflection<TestOpAWithReflection, T>;
+  }
+
+  FieldReflection<TestOpAWithReflection, dynamic>? _staticFieldImpl(
+      String fieldName) {
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'staticfielda':
-        return FieldReflection<TestOpAWithReflection, T>(
+        return FieldReflection<TestOpAWithReflection, int>(
           this,
           TestOpAWithReflection,
           __TR.tInt,
           'staticFieldA',
           false,
-          (o) => () => TestOpAWithReflection.staticFieldA as T,
-          (o) => (T? v) => TestOpAWithReflection.staticFieldA = v as int,
+          (o) => () => TestOpAWithReflection.staticFieldA,
+          (o) => (v) => TestOpAWithReflection.staticFieldA = v,
           null,
           true,
           false,
@@ -1629,16 +2596,63 @@ class TestOpAWithReflection$reflection
   @override
   List<String> get methodsNames => const <String>['isEmptyType', 'methodA'];
 
+  static final Map<String, MethodReflection<TestOpAWithReflection, dynamic>>
+      _methodsNoObject =
+      <String, MethodReflection<TestOpAWithReflection, dynamic>>{};
+
+  final Map<String, MethodReflection<TestOpAWithReflection, dynamic>>
+      _methodsObject =
+      <String, MethodReflection<TestOpAWithReflection, dynamic>>{};
+
   @override
   MethodReflection<TestOpAWithReflection, R>? method<R>(String methodName,
       [TestOpAWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<TestOpAWithReflection, R>? _methodNoObjectImpl<R>(
+      String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestOpAWithReflection, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<TestOpAWithReflection, R>;
+  }
+
+  MethodReflection<TestOpAWithReflection, R>? _methodObjectImpl<R>(
+      String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestOpAWithReflection, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<TestOpAWithReflection, dynamic>? _methodImpl(
+      String methodName, TestOpAWithReflection? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'methoda':
-        return MethodReflection<TestOpAWithReflection, R>(
+        return MethodReflection<TestOpAWithReflection, bool>(
             this,
             TestOpAWithReflection,
             'methodA',
@@ -1652,7 +2666,7 @@ class TestOpAWithReflection$reflection
             null,
             null);
       case 'isemptytype':
-        return MethodReflection<TestOpAWithReflection, R>(
+        return MethodReflection<TestOpAWithReflection, bool>(
             this,
             TestOpWithReflection,
             'isEmptyType',
@@ -1675,9 +2689,8 @@ class TestOpAWithReflection$reflection
 
   @override
   MethodReflection<TestOpAWithReflection, R>? staticMethod<R>(
-      String methodName) {
-    return null;
-  }
+          String methodName) =>
+      null;
 }
 
 class TestOpBWithReflection$reflection
@@ -1738,8 +2751,21 @@ class TestOpBWithReflection$reflection
   @override
   List<String> get constructorsNames => const <String>[''];
 
+  static final Map<String, ConstructorReflection<TestOpBWithReflection>>
+      _constructors = <String, ConstructorReflection<TestOpBWithReflection>>{};
+
   @override
-  ConstructorReflection<TestOpBWithReflection>? constructor<R>(
+  ConstructorReflection<TestOpBWithReflection>? constructor(
+      String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestOpBWithReflection>? _constructorImpl(
       String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
@@ -1774,49 +2800,96 @@ class TestOpBWithReflection$reflection
   @override
   List<String> get fieldsNames => const <String>['amount', 'type', 'value'];
 
+  static final Map<String, FieldReflection<TestOpBWithReflection, dynamic>>
+      _fieldsNoObject =
+      <String, FieldReflection<TestOpBWithReflection, dynamic>>{};
+
+  final Map<String, FieldReflection<TestOpBWithReflection, dynamic>>
+      _fieldsObject =
+      <String, FieldReflection<TestOpBWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestOpBWithReflection, T>? field<T>(String fieldName,
       [TestOpBWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestOpBWithReflection, T>? _fieldNoObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestOpBWithReflection, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestOpBWithReflection, T>;
+  }
+
+  FieldReflection<TestOpBWithReflection, T>? _fieldObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestOpBWithReflection, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestOpBWithReflection, dynamic>? _fieldImpl(
+      String fieldName, TestOpBWithReflection? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'amount':
-        return FieldReflection<TestOpBWithReflection, T>(
+        return FieldReflection<TestOpBWithReflection, double>(
           this,
           TestOpBWithReflection,
           __TR.tDouble,
           'amount',
           false,
-          (o) => () => o!.amount as T,
-          (o) => (T? v) => o!.amount = v as double,
+          (o) => () => o!.amount,
+          (o) => (v) => o!.amount = v,
           obj,
           false,
           false,
         );
       case 'type':
-        return FieldReflection<TestOpBWithReflection, T>(
+        return FieldReflection<TestOpBWithReflection, String>(
           this,
           TestOpWithReflection,
           __TR.tString,
           'type',
           false,
-          (o) => () => o!.type as T,
+          (o) => () => o!.type,
           null,
           obj,
           false,
           true,
         );
       case 'value':
-        return FieldReflection<TestOpBWithReflection, T>(
+        return FieldReflection<TestOpBWithReflection, dynamic>(
           this,
           WithValue,
           __TR.tDynamic,
           'value',
           true,
-          (o) => () => o!.value as T,
-          (o) => (T? v) => o!.value = v as dynamic,
+          (o) => () => o!.value,
+          (o) => (v) => o!.value = v,
           obj,
           false,
           false,
@@ -1830,23 +2903,69 @@ class TestOpBWithReflection$reflection
   List<String> get staticFieldsNames => const <String>[];
 
   @override
-  FieldReflection<TestOpBWithReflection, T>? staticField<T>(String fieldName) {
-    return null;
-  }
+  FieldReflection<TestOpBWithReflection, T>? staticField<T>(String fieldName) =>
+      null;
 
   @override
   List<String> get methodsNames => const <String>['isEmptyType', 'methodB'];
 
+  static final Map<String, MethodReflection<TestOpBWithReflection, dynamic>>
+      _methodsNoObject =
+      <String, MethodReflection<TestOpBWithReflection, dynamic>>{};
+
+  final Map<String, MethodReflection<TestOpBWithReflection, dynamic>>
+      _methodsObject =
+      <String, MethodReflection<TestOpBWithReflection, dynamic>>{};
+
   @override
   MethodReflection<TestOpBWithReflection, R>? method<R>(String methodName,
       [TestOpBWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<TestOpBWithReflection, R>? _methodNoObjectImpl<R>(
+      String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestOpBWithReflection, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<TestOpBWithReflection, R>;
+  }
+
+  MethodReflection<TestOpBWithReflection, R>? _methodObjectImpl<R>(
+      String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestOpBWithReflection, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<TestOpBWithReflection, dynamic>? _methodImpl(
+      String methodName, TestOpBWithReflection? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'methodb':
-        return MethodReflection<TestOpBWithReflection, R>(
+        return MethodReflection<TestOpBWithReflection, Set<dynamic>>(
             this,
             TestOpBWithReflection,
             'methodB',
@@ -1860,7 +2979,7 @@ class TestOpBWithReflection$reflection
             null,
             null);
       case 'isemptytype':
-        return MethodReflection<TestOpBWithReflection, R>(
+        return MethodReflection<TestOpBWithReflection, bool>(
             this,
             TestOpWithReflection,
             'isEmptyType',
@@ -1881,14 +3000,30 @@ class TestOpBWithReflection$reflection
   @override
   List<String> get staticMethodsNames => const <String>['staticMethodB'];
 
+  static final Map<String, MethodReflection<TestOpBWithReflection, dynamic>>
+      _staticMethods =
+      <String, MethodReflection<TestOpBWithReflection, dynamic>>{};
+
   @override
   MethodReflection<TestOpBWithReflection, R>? staticMethod<R>(
+      String methodName) {
+    var m = _staticMethods[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestOpBWithReflection, R>;
+    }
+    m = _staticMethodImpl(methodName);
+    if (m == null) return null;
+    _staticMethods[methodName] = m;
+    return m as MethodReflection<TestOpBWithReflection, R>;
+  }
+
+  MethodReflection<TestOpBWithReflection, dynamic>? _staticMethodImpl(
       String methodName) {
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'staticmethodb':
-        return MethodReflection<TestOpBWithReflection, R>(
+        return MethodReflection<TestOpBWithReflection, bool>(
             this,
             TestOpBWithReflection,
             'staticMethodB',
@@ -1967,8 +3102,21 @@ class TestOpWithReflection$reflection
   @override
   List<String> get constructorsNames => const <String>['', 'empty'];
 
+  static final Map<String, ConstructorReflection<TestOpWithReflection>>
+      _constructors = <String, ConstructorReflection<TestOpWithReflection>>{};
+
   @override
-  ConstructorReflection<TestOpWithReflection>? constructor<R>(
+  ConstructorReflection<TestOpWithReflection>? constructor(
+      String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestOpWithReflection>? _constructorImpl(
       String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
@@ -2017,36 +3165,83 @@ class TestOpWithReflection$reflection
   @override
   List<String> get fieldsNames => const <String>['type', 'value'];
 
+  static final Map<String, FieldReflection<TestOpWithReflection, dynamic>>
+      _fieldsNoObject =
+      <String, FieldReflection<TestOpWithReflection, dynamic>>{};
+
+  final Map<String, FieldReflection<TestOpWithReflection, dynamic>>
+      _fieldsObject =
+      <String, FieldReflection<TestOpWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestOpWithReflection, T>? field<T>(String fieldName,
       [TestOpWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestOpWithReflection, T>? _fieldNoObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestOpWithReflection, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestOpWithReflection, T>;
+  }
+
+  FieldReflection<TestOpWithReflection, T>? _fieldObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestOpWithReflection, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestOpWithReflection, dynamic>? _fieldImpl(
+      String fieldName, TestOpWithReflection? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'type':
-        return FieldReflection<TestOpWithReflection, T>(
+        return FieldReflection<TestOpWithReflection, String>(
           this,
           TestOpWithReflection,
           __TR.tString,
           'type',
           false,
-          (o) => () => o!.type as T,
+          (o) => () => o!.type,
           null,
           obj,
           false,
           true,
         );
       case 'value':
-        return FieldReflection<TestOpWithReflection, T>(
+        return FieldReflection<TestOpWithReflection, dynamic>(
           this,
           WithValue,
           __TR.tDynamic,
           'value',
           true,
-          (o) => () => o!.value as T,
-          (o) => (T? v) => o!.value = v as dynamic,
+          (o) => () => o!.value,
+          (o) => (v) => o!.value = v,
           obj,
           false,
           false,
@@ -2059,20 +3254,36 @@ class TestOpWithReflection$reflection
   @override
   List<String> get staticFieldsNames => const <String>['staticField'];
 
+  static final Map<String, FieldReflection<TestOpWithReflection, dynamic>>
+      _staticFields =
+      <String, FieldReflection<TestOpWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestOpWithReflection, T>? staticField<T>(String fieldName) {
+    var f = _staticFields[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestOpWithReflection, T>;
+    }
+    f = _staticFieldImpl(fieldName);
+    if (f == null) return null;
+    _staticFields[fieldName] = f;
+    return f as FieldReflection<TestOpWithReflection, T>;
+  }
+
+  FieldReflection<TestOpWithReflection, dynamic>? _staticFieldImpl(
+      String fieldName) {
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'staticfield':
-        return FieldReflection<TestOpWithReflection, T>(
+        return FieldReflection<TestOpWithReflection, int>(
           this,
           TestOpWithReflection,
           __TR.tInt,
           'staticField',
           false,
-          (o) => () => TestOpWithReflection.staticField as T,
-          (o) => (T? v) => TestOpWithReflection.staticField = v as int,
+          (o) => () => TestOpWithReflection.staticField,
+          (o) => (v) => TestOpWithReflection.staticField = v,
           null,
           true,
           false,
@@ -2086,16 +3297,63 @@ class TestOpWithReflection$reflection
   @override
   List<String> get methodsNames => const <String>['isEmptyType'];
 
+  static final Map<String, MethodReflection<TestOpWithReflection, dynamic>>
+      _methodsNoObject =
+      <String, MethodReflection<TestOpWithReflection, dynamic>>{};
+
+  final Map<String, MethodReflection<TestOpWithReflection, dynamic>>
+      _methodsObject =
+      <String, MethodReflection<TestOpWithReflection, dynamic>>{};
+
   @override
   MethodReflection<TestOpWithReflection, R>? method<R>(String methodName,
       [TestOpWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<TestOpWithReflection, R>? _methodNoObjectImpl<R>(
+      String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestOpWithReflection, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<TestOpWithReflection, R>;
+  }
+
+  MethodReflection<TestOpWithReflection, R>? _methodObjectImpl<R>(
+      String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestOpWithReflection, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<TestOpWithReflection, dynamic>? _methodImpl(
+      String methodName, TestOpWithReflection? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'isemptytype':
-        return MethodReflection<TestOpWithReflection, R>(
+        return MethodReflection<TestOpWithReflection, bool>(
             this,
             TestOpWithReflection,
             'isEmptyType',
@@ -2116,14 +3374,30 @@ class TestOpWithReflection$reflection
   @override
   List<String> get staticMethodsNames => const <String>['staticMethod'];
 
+  static final Map<String, MethodReflection<TestOpWithReflection, dynamic>>
+      _staticMethods =
+      <String, MethodReflection<TestOpWithReflection, dynamic>>{};
+
   @override
   MethodReflection<TestOpWithReflection, R>? staticMethod<R>(
+      String methodName) {
+    var m = _staticMethods[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestOpWithReflection, R>;
+    }
+    m = _staticMethodImpl(methodName);
+    if (m == null) return null;
+    _staticMethods[methodName] = m;
+    return m as MethodReflection<TestOpWithReflection, R>;
+  }
+
+  MethodReflection<TestOpWithReflection, dynamic>? _staticMethodImpl(
       String methodName) {
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'staticmethod':
-        return MethodReflection<TestOpWithReflection, R>(
+        return MethodReflection<TestOpWithReflection, bool>(
             this,
             TestOpWithReflection,
             'staticMethod',
@@ -2206,8 +3480,22 @@ class TestTransactionWithReflection$reflection
   @override
   List<String> get constructorsNames => const <String>['fromTo'];
 
+  static final Map<String, ConstructorReflection<TestTransactionWithReflection>>
+      _constructors =
+      <String, ConstructorReflection<TestTransactionWithReflection>>{};
+
   @override
-  ConstructorReflection<TestTransactionWithReflection>? constructor<R>(
+  ConstructorReflection<TestTransactionWithReflection>? constructor(
+      String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestTransactionWithReflection>? _constructorImpl(
       String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
@@ -2251,48 +3539,98 @@ class TestTransactionWithReflection$reflection
   List<String> get fieldsNames =>
       const <String>['amount', 'fromUser', 'toUser'];
 
+  static final Map<String,
+          FieldReflection<TestTransactionWithReflection, dynamic>>
+      _fieldsNoObject =
+      <String, FieldReflection<TestTransactionWithReflection, dynamic>>{};
+
+  final Map<String, FieldReflection<TestTransactionWithReflection, dynamic>>
+      _fieldsObject =
+      <String, FieldReflection<TestTransactionWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestTransactionWithReflection, T>? field<T>(String fieldName,
       [TestTransactionWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestTransactionWithReflection, T>? _fieldNoObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestTransactionWithReflection, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestTransactionWithReflection, T>;
+  }
+
+  FieldReflection<TestTransactionWithReflection, T>? _fieldObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestTransactionWithReflection, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestTransactionWithReflection, dynamic>? _fieldImpl(
+      String fieldName, TestTransactionWithReflection? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'fromuser':
-        return FieldReflection<TestTransactionWithReflection, T>(
+        return FieldReflection<TestTransactionWithReflection,
+            TestUserWithReflection>(
           this,
           TestTransactionWithReflection,
           __TR<TestUserWithReflection>(TestUserWithReflection),
           'fromUser',
           false,
-          (o) => () => o!.fromUser as T,
+          (o) => () => o!.fromUser,
           null,
           obj,
           false,
           true,
         );
       case 'touser':
-        return FieldReflection<TestTransactionWithReflection, T>(
+        return FieldReflection<TestTransactionWithReflection,
+            TestUserWithReflection>(
           this,
           TestTransactionWithReflection,
           __TR<TestUserWithReflection>(TestUserWithReflection),
           'toUser',
           false,
-          (o) => () => o!.toUser as T,
+          (o) => () => o!.toUser,
           null,
           obj,
           false,
           true,
         );
       case 'amount':
-        return FieldReflection<TestTransactionWithReflection, T>(
+        return FieldReflection<TestTransactionWithReflection, int>(
           this,
           TestTransactionWithReflection,
           __TR.tInt,
           'amount',
           false,
-          (o) => () => o!.amount as T,
+          (o) => () => o!.amount,
           null,
           obj,
           false,
@@ -2308,30 +3646,24 @@ class TestTransactionWithReflection$reflection
 
   @override
   FieldReflection<TestTransactionWithReflection, T>? staticField<T>(
-      String fieldName) {
-    return null;
-  }
+          String fieldName) =>
+      null;
 
   @override
   List<String> get methodsNames => const <String>[];
 
   @override
   MethodReflection<TestTransactionWithReflection, R>? method<R>(
-      String methodName,
-      [TestTransactionWithReflection? obj]) {
-    obj ??= object;
-
-    return null;
-  }
-
+          String methodName,
+          [TestTransactionWithReflection? obj]) =>
+      null;
   @override
   List<String> get staticMethodsNames => const <String>[];
 
   @override
   MethodReflection<TestTransactionWithReflection, R>? staticMethod<R>(
-      String methodName) {
-    return null;
-  }
+          String methodName) =>
+      null;
 }
 
 class TestUserWithReflection$reflection
@@ -2393,8 +3725,21 @@ class TestUserWithReflection$reflection
   @override
   List<String> get constructorsNames => const <String>['', 'fields'];
 
+  static final Map<String, ConstructorReflection<TestUserWithReflection>>
+      _constructors = <String, ConstructorReflection<TestUserWithReflection>>{};
+
   @override
-  ConstructorReflection<TestUserWithReflection>? constructor<R>(
+  ConstructorReflection<TestUserWithReflection>? constructor(
+      String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestUserWithReflection>? _constructorImpl(
       String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
@@ -2467,114 +3812,161 @@ class TestUserWithReflection$reflection
         'password'
       ];
 
+  static final Map<String, FieldReflection<TestUserWithReflection, dynamic>>
+      _fieldsNoObject =
+      <String, FieldReflection<TestUserWithReflection, dynamic>>{};
+
+  final Map<String, FieldReflection<TestUserWithReflection, dynamic>>
+      _fieldsObject =
+      <String, FieldReflection<TestUserWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestUserWithReflection, T>? field<T>(String fieldName,
       [TestUserWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestUserWithReflection, T>? _fieldNoObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestUserWithReflection, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestUserWithReflection, T>;
+  }
+
+  FieldReflection<TestUserWithReflection, T>? _fieldObjectImpl<T>(
+      String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestUserWithReflection, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestUserWithReflection, dynamic>? _fieldImpl(
+      String fieldName, TestUserWithReflection? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'id':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, int?>(
           this,
           TestUserWithReflection,
           __TR.tInt,
           'id',
           true,
-          (o) => () => o!.id as T,
-          (o) => (T? v) => o!.id = v as int?,
+          (o) => () => o!.id,
+          (o) => (v) => o!.id = v,
           obj,
           false,
           false,
         );
       case 'name':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, String>(
           this,
           TestUserWithReflection,
           __TR.tString,
           'name',
           false,
-          (o) => () => o!.name as T,
+          (o) => () => o!.name,
           null,
           obj,
           false,
           true,
         );
       case 'email':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, String?>(
           this,
           TestUserWithReflection,
           __TR.tString,
           'email',
           true,
-          (o) => () => o!.email as T,
-          (o) => (T? v) => o!.email = v as String?,
+          (o) => () => o!.email,
+          (o) => (v) => o!.email = v,
           obj,
           false,
           false,
         );
       case 'password':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, String>(
           this,
           TestUserWithReflection,
           __TR.tString,
           'password',
           false,
-          (o) => () => o!.password as T,
-          (o) => (T? v) => o!.password = v as String,
+          (o) => () => o!.password,
+          (o) => (v) => o!.password = v,
           obj,
           false,
           false,
         );
       case 'enabled':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, bool>(
           this,
           TestUserWithReflection,
           __TR.tBool,
           'enabled',
           false,
-          (o) => () => o!.enabled as T,
-          (o) => (T? v) => o!.enabled = v as bool,
+          (o) => () => o!.enabled,
+          (o) => (v) => o!.enabled = v,
           obj,
           false,
           false,
         );
       case 'axis':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, TestEnumWithReflection>(
           this,
           TestUserWithReflection,
           __TR<TestEnumWithReflection>(TestEnumWithReflection),
           'axis',
           false,
-          (o) => () => o!.axis as T,
-          (o) => (T? v) => o!.axis = v as TestEnumWithReflection,
+          (o) => () => o!.axis,
+          (o) => (v) => o!.axis = v,
           obj,
           false,
           false,
         );
       case 'level':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, int?>(
           this,
           TestUserWithReflection,
           __TR.tInt,
           'level',
           true,
-          (o) => () => o!.level as T,
-          (o) => (T? v) => o!.level = v as int?,
+          (o) => () => o!.level,
+          (o) => (v) => o!.level = v,
           obj,
           false,
           false,
           [JsonFieldAlias('theLevel')],
         );
       case 'isenabled':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, bool>(
           this,
           TestUserWithReflection,
           __TR.tBool,
           'isEnabled',
           false,
-          (o) => () => o!.isEnabled as T,
+          (o) => () => o!.isEnabled,
           null,
           obj,
           false,
@@ -2582,13 +3974,13 @@ class TestUserWithReflection$reflection
           [JsonField.visible()],
         );
       case 'isnotenabled':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, bool>(
           this,
           TestUserWithReflection,
           __TR.tBool,
           'isNotEnabled',
           false,
-          (o) => () => o!.isNotEnabled as T,
+          (o) => () => o!.isNotEnabled,
           null,
           obj,
           false,
@@ -2596,13 +3988,13 @@ class TestUserWithReflection$reflection
           [JsonField.hidden()],
         );
       case 'hashcode':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, int>(
           this,
           TestUserWithReflection,
           __TR.tInt,
           'hashCode',
           false,
-          (o) => () => o!.hashCode as T,
+          (o) => () => o!.hashCode,
           null,
           obj,
           false,
@@ -2618,19 +4010,35 @@ class TestUserWithReflection$reflection
   List<String> get staticFieldsNames =>
       const <String>['version', 'withReflection'];
 
+  static final Map<String, FieldReflection<TestUserWithReflection, dynamic>>
+      _staticFields =
+      <String, FieldReflection<TestUserWithReflection, dynamic>>{};
+
   @override
   FieldReflection<TestUserWithReflection, T>? staticField<T>(String fieldName) {
+    var f = _staticFields[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestUserWithReflection, T>;
+    }
+    f = _staticFieldImpl(fieldName);
+    if (f == null) return null;
+    _staticFields[fieldName] = f;
+    return f as FieldReflection<TestUserWithReflection, T>;
+  }
+
+  FieldReflection<TestUserWithReflection, dynamic>? _staticFieldImpl(
+      String fieldName) {
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'version':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, double>(
           this,
           TestUserWithReflection,
           __TR.tDouble,
           'version',
           false,
-          (o) => () => TestUserWithReflection.version as T,
+          (o) => () => TestUserWithReflection.version,
           null,
           null,
           true,
@@ -2638,13 +4046,13 @@ class TestUserWithReflection$reflection
           null,
         );
       case 'withreflection':
-        return FieldReflection<TestUserWithReflection, T>(
+        return FieldReflection<TestUserWithReflection, bool>(
           this,
           TestUserWithReflection,
           __TR.tBool,
           'withReflection',
           false,
-          (o) => () => TestUserWithReflection.withReflection as T,
+          (o) => () => TestUserWithReflection.withReflection,
           null,
           null,
           true,
@@ -2660,16 +4068,63 @@ class TestUserWithReflection$reflection
   List<String> get methodsNames =>
       const <String>['checkPassword', 'getField', 'setField', 'toString'];
 
+  static final Map<String, MethodReflection<TestUserWithReflection, dynamic>>
+      _methodsNoObject =
+      <String, MethodReflection<TestUserWithReflection, dynamic>>{};
+
+  final Map<String, MethodReflection<TestUserWithReflection, dynamic>>
+      _methodsObject =
+      <String, MethodReflection<TestUserWithReflection, dynamic>>{};
+
   @override
   MethodReflection<TestUserWithReflection, R>? method<R>(String methodName,
       [TestUserWithReflection? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<TestUserWithReflection, R>? _methodNoObjectImpl<R>(
+      String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestUserWithReflection, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<TestUserWithReflection, R>;
+  }
+
+  MethodReflection<TestUserWithReflection, R>? _methodObjectImpl<R>(
+      String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestUserWithReflection, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<TestUserWithReflection, dynamic>? _methodImpl(
+      String methodName, TestUserWithReflection? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'checkpassword':
-        return MethodReflection<TestUserWithReflection, R>(
+        return MethodReflection<TestUserWithReflection, bool>(
             this,
             TestUserWithReflection,
             'checkPassword',
@@ -2683,7 +4138,7 @@ class TestUserWithReflection$reflection
             null,
             null);
       case 'getfield':
-        return MethodReflection<TestUserWithReflection, R>(
+        return MethodReflection<TestUserWithReflection, dynamic>(
             this,
             TestUserWithReflection,
             'getField',
@@ -2697,7 +4152,7 @@ class TestUserWithReflection$reflection
             null,
             null);
       case 'setfield':
-        return MethodReflection<TestUserWithReflection, R>(
+        return MethodReflection<TestUserWithReflection, void>(
             this,
             TestUserWithReflection,
             'setField',
@@ -2716,7 +4171,7 @@ class TestUserWithReflection$reflection
             },
             null);
       case 'tostring':
-        return MethodReflection<TestUserWithReflection, R>(
+        return MethodReflection<TestUserWithReflection, String>(
             this,
             TestUserWithReflection,
             'toString',
@@ -2737,14 +4192,30 @@ class TestUserWithReflection$reflection
   @override
   List<String> get staticMethodsNames => const <String>['isVersion'];
 
+  static final Map<String, MethodReflection<TestUserWithReflection, dynamic>>
+      _staticMethods =
+      <String, MethodReflection<TestUserWithReflection, dynamic>>{};
+
   @override
   MethodReflection<TestUserWithReflection, R>? staticMethod<R>(
+      String methodName) {
+    var m = _staticMethods[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestUserWithReflection, R>;
+    }
+    m = _staticMethodImpl(methodName);
+    if (m == null) return null;
+    _staticMethods[methodName] = m;
+    return m as MethodReflection<TestUserWithReflection, R>;
+  }
+
+  MethodReflection<TestUserWithReflection, dynamic>? _staticMethodImpl(
       String methodName) {
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'isversion':
-        return MethodReflection<TestUserWithReflection, R>(
+        return MethodReflection<TestUserWithReflection, bool>(
             this,
             TestUserWithReflection,
             'isVersion',
@@ -2854,6 +4325,29 @@ extension TestDomainWithReflection$reflectionExtension
       .toJsonFromFields(duplicatedEntitiesAsID: duplicatedEntitiesAsID);
 }
 
+extension TestEmpty$reflectionExtension on TestEmpty {
+  /// Returns a [ClassReflection] for type [TestEmpty]. (Generated by [ReflectionFactory])
+  ClassReflection<TestEmpty> get reflection => TestEmpty$reflection(this);
+
+  /// Returns a JSON for type [TestEmpty]. (Generated by [ReflectionFactory])
+  Object? toJson({bool duplicatedEntitiesAsID = false}) =>
+      reflection.toJson(null, null, duplicatedEntitiesAsID);
+
+  /// Returns a JSON [Map] for type [TestEmpty]. (Generated by [ReflectionFactory])
+  Map<String, dynamic>? toJsonMap({bool duplicatedEntitiesAsID = false}) =>
+      reflection.toJsonMap(duplicatedEntitiesAsID: duplicatedEntitiesAsID);
+
+  /// Returns an encoded JSON [String] for type [TestEmpty]. (Generated by [ReflectionFactory])
+  String toJsonEncoded(
+          {bool pretty = false, bool duplicatedEntitiesAsID = false}) =>
+      reflection.toJsonEncoded(
+          pretty: pretty, duplicatedEntitiesAsID: duplicatedEntitiesAsID);
+
+  /// Returns a JSON for type [TestEmpty] using the class fields. (Generated by [ReflectionFactory])
+  Object? toJsonFromFields({bool duplicatedEntitiesAsID = false}) => reflection
+      .toJsonFromFields(duplicatedEntitiesAsID: duplicatedEntitiesAsID);
+}
+
 extension TestEnumWithReflection$reflectionExtension on TestEnumWithReflection {
   /// Returns a [EnumReflection] for type [TestEnumWithReflection]. (Generated by [ReflectionFactory])
   EnumReflection<TestEnumWithReflection> get reflection =>
@@ -2894,6 +4388,29 @@ extension TestFranchiseWithReflection$reflectionExtension
           pretty: pretty, duplicatedEntitiesAsID: duplicatedEntitiesAsID);
 
   /// Returns a JSON for type [TestFranchiseWithReflection] using the class fields. (Generated by [ReflectionFactory])
+  Object? toJsonFromFields({bool duplicatedEntitiesAsID = false}) => reflection
+      .toJsonFromFields(duplicatedEntitiesAsID: duplicatedEntitiesAsID);
+}
+
+extension TestName$reflectionExtension on TestName {
+  /// Returns a [ClassReflection] for type [TestName]. (Generated by [ReflectionFactory])
+  ClassReflection<TestName> get reflection => TestName$reflection(this);
+
+  /// Returns a JSON for type [TestName]. (Generated by [ReflectionFactory])
+  Object? toJson({bool duplicatedEntitiesAsID = false}) =>
+      reflection.toJson(null, null, duplicatedEntitiesAsID);
+
+  /// Returns a JSON [Map] for type [TestName]. (Generated by [ReflectionFactory])
+  Map<String, dynamic>? toJsonMap({bool duplicatedEntitiesAsID = false}) =>
+      reflection.toJsonMap(duplicatedEntitiesAsID: duplicatedEntitiesAsID);
+
+  /// Returns an encoded JSON [String] for type [TestName]. (Generated by [ReflectionFactory])
+  String toJsonEncoded(
+          {bool pretty = false, bool duplicatedEntitiesAsID = false}) =>
+      reflection.toJsonEncoded(
+          pretty: pretty, duplicatedEntitiesAsID: duplicatedEntitiesAsID);
+
+  /// Returns a JSON for type [TestName] using the class fields. (Generated by [ReflectionFactory])
   Object? toJsonFromFields({bool duplicatedEntitiesAsID = false}) => reflection
       .toJsonFromFields(duplicatedEntitiesAsID: duplicatedEntitiesAsID);
 }
@@ -3030,6 +4547,8 @@ List<Reflection> _listSiblingsReflection() => <Reflection>[
       TestOpAWithReflection$reflection(),
       TestOpBWithReflection$reflection(),
       TestTransactionWithReflection$reflection(),
+      TestName$reflection(),
+      TestEmpty$reflection(),
       TestEnumWithReflection$reflection(),
     ];
 

--- a/test/src/user_reflection_bridge.reflection.g.dart
+++ b/test/src/user_reflection_bridge.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.25
+// BUILDER: reflection_factory/2.0.0
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('1.2.25');
+  static final Version _version = Version.parse('2.0.0');
 
   Version get reflectionFactoryVersion => _version;
 
@@ -94,8 +94,20 @@ class TestAddress$reflection extends ClassReflection<TestAddress>
   @override
   List<String> get constructorsNames => const <String>[''];
 
+  static final Map<String, ConstructorReflection<TestAddress>> _constructors =
+      <String, ConstructorReflection<TestAddress>>{};
+
   @override
-  ConstructorReflection<TestAddress>? constructor<R>(String constructorName) {
+  ConstructorReflection<TestAddress>? constructor(String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestAddress>? _constructorImpl(String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
     switch (lc) {
@@ -135,48 +147,91 @@ class TestAddress$reflection extends ClassReflection<TestAddress>
   @override
   List<String> get fieldsNames => const <String>['city', 'hashCode', 'state'];
 
+  static final Map<String, FieldReflection<TestAddress, dynamic>>
+      _fieldsNoObject = <String, FieldReflection<TestAddress, dynamic>>{};
+
+  final Map<String, FieldReflection<TestAddress, dynamic>> _fieldsObject =
+      <String, FieldReflection<TestAddress, dynamic>>{};
+
   @override
   FieldReflection<TestAddress, T>? field<T>(String fieldName,
       [TestAddress? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestAddress, T>? _fieldNoObjectImpl<T>(String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestAddress, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestAddress, T>;
+  }
+
+  FieldReflection<TestAddress, T>? _fieldObjectImpl<T>(String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestAddress, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestAddress, dynamic>? _fieldImpl(
+      String fieldName, TestAddress? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'state':
-        return FieldReflection<TestAddress, T>(
+        return FieldReflection<TestAddress, String>(
           this,
           TestAddress,
           __TR.tString,
           'state',
           false,
-          (o) => () => o!.state as T,
+          (o) => () => o!.state,
           null,
           obj,
           false,
           true,
         );
       case 'city':
-        return FieldReflection<TestAddress, T>(
+        return FieldReflection<TestAddress, String>(
           this,
           TestAddress,
           __TR.tString,
           'city',
           false,
-          (o) => () => o!.city as T,
+          (o) => () => o!.city,
           null,
           obj,
           false,
           true,
         );
       case 'hashcode':
-        return FieldReflection<TestAddress, T>(
+        return FieldReflection<TestAddress, int>(
           this,
           TestAddress,
           __TR.tInt,
           'hashCode',
           false,
-          (o) => () => o!.hashCode as T,
+          (o) => () => o!.hashCode,
           null,
           obj,
           false,
@@ -192,23 +247,64 @@ class TestAddress$reflection extends ClassReflection<TestAddress>
   List<String> get staticFieldsNames => const <String>[];
 
   @override
-  FieldReflection<TestAddress, T>? staticField<T>(String fieldName) {
-    return null;
-  }
+  FieldReflection<TestAddress, T>? staticField<T>(String fieldName) => null;
 
   @override
   List<String> get methodsNames => const <String>['toJson'];
 
+  static final Map<String, MethodReflection<TestAddress, dynamic>>
+      _methodsNoObject = <String, MethodReflection<TestAddress, dynamic>>{};
+
+  final Map<String, MethodReflection<TestAddress, dynamic>> _methodsObject =
+      <String, MethodReflection<TestAddress, dynamic>>{};
+
   @override
   MethodReflection<TestAddress, R>? method<R>(String methodName,
       [TestAddress? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<TestAddress, R>? _methodNoObjectImpl<R>(String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestAddress, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<TestAddress, R>;
+  }
+
+  MethodReflection<TestAddress, R>? _methodObjectImpl<R>(String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestAddress, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<TestAddress, dynamic>? _methodImpl(
+      String methodName, TestAddress? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'tojson':
-        return MethodReflection<TestAddress, R>(
+        return MethodReflection<TestAddress, Map<String, dynamic>>(
             this,
             TestAddress,
             'toJson',
@@ -230,9 +326,7 @@ class TestAddress$reflection extends ClassReflection<TestAddress>
   List<String> get staticMethodsNames => const <String>[];
 
   @override
-  MethodReflection<TestAddress, R>? staticMethod<R>(String methodName) {
-    return null;
-  }
+  MethodReflection<TestAddress, R>? staticMethod<R>(String methodName) => null;
 }
 
 class TestUserSimple$reflection extends ClassReflection<TestUserSimple>
@@ -295,8 +389,20 @@ class TestUserSimple$reflection extends ClassReflection<TestUserSimple>
   @override
   List<String> get constructorsNames => const <String>['', 'empty'];
 
+  static final Map<String, ConstructorReflection<TestUserSimple>>
+      _constructors = <String, ConstructorReflection<TestUserSimple>>{};
+
   @override
-  ConstructorReflection<TestUserSimple>? constructor<R>(
+  ConstructorReflection<TestUserSimple>? constructor(String constructorName) {
+    var c = _constructors[constructorName];
+    if (c != null) return c;
+    c = _constructorImpl(constructorName);
+    if (c == null) return null;
+    _constructors[constructorName] = c;
+    return c;
+  }
+
+  ConstructorReflection<TestUserSimple>? _constructorImpl(
       String constructorName) {
     var lc = constructorName.trim().toLowerCase();
 
@@ -352,22 +458,65 @@ class TestUserSimple$reflection extends ClassReflection<TestUserSimple>
   List<String> get fieldsNames =>
       const <String>['email', 'hashCode', 'name', 'password'];
 
+  static final Map<String, FieldReflection<TestUserSimple, dynamic>>
+      _fieldsNoObject = <String, FieldReflection<TestUserSimple, dynamic>>{};
+
+  final Map<String, FieldReflection<TestUserSimple, dynamic>> _fieldsObject =
+      <String, FieldReflection<TestUserSimple, dynamic>>{};
+
   @override
   FieldReflection<TestUserSimple, T>? field<T>(String fieldName,
       [TestUserSimple? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _fieldObjectImpl<T>(fieldName);
+      } else {
+        return _fieldNoObjectImpl<T>(fieldName);
+      }
+    } else if (identical(obj, object)) {
+      return _fieldObjectImpl<T>(fieldName);
+    }
+    return _fieldNoObjectImpl<T>(fieldName)?.withObject(obj);
+  }
+
+  FieldReflection<TestUserSimple, T>? _fieldNoObjectImpl<T>(String fieldName) {
+    final f = _fieldsNoObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestUserSimple, T>;
+    }
+    final f2 = _fieldImpl(fieldName, null);
+    if (f2 == null) return null;
+    _fieldsNoObject[fieldName] = f2;
+    return f2 as FieldReflection<TestUserSimple, T>;
+  }
+
+  FieldReflection<TestUserSimple, T>? _fieldObjectImpl<T>(String fieldName) {
+    final f = _fieldsObject[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestUserSimple, T>;
+    }
+    var f2 = _fieldNoObjectImpl<T>(fieldName);
+    if (f2 == null) return null;
+    f2 = f2.withObject(object!);
+    _fieldsObject[fieldName] = f2;
+    return f2;
+  }
+
+  FieldReflection<TestUserSimple, dynamic>? _fieldImpl(
+      String fieldName, TestUserSimple? obj) {
     obj ??= object;
 
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'name':
-        return FieldReflection<TestUserSimple, T>(
+        return FieldReflection<TestUserSimple, String>(
           this,
           TestUserSimple,
           __TR.tString,
           'name',
           false,
-          (o) => () => o!.name as T,
+          (o) => () => o!.name,
           null,
           obj,
           false,
@@ -377,39 +526,39 @@ class TestUserSimple$reflection extends ClassReflection<TestUserSimple>
           ],
         );
       case 'email':
-        return FieldReflection<TestUserSimple, T>(
+        return FieldReflection<TestUserSimple, String?>(
           this,
           TestUserSimple,
           __TR.tString,
           'email',
           true,
-          (o) => () => o!.email as T,
-          (o) => (T? v) => o!.email = v as String?,
+          (o) => () => o!.email,
+          (o) => (v) => o!.email = v,
           obj,
           false,
           false,
         );
       case 'password':
-        return FieldReflection<TestUserSimple, T>(
+        return FieldReflection<TestUserSimple, String>(
           this,
           TestUserSimple,
           __TR.tString,
           'password',
           false,
-          (o) => () => o!.password as T,
-          (o) => (T? v) => o!.password = v as String,
+          (o) => () => o!.password,
+          (o) => (v) => o!.password = v,
           obj,
           false,
           false,
         );
       case 'hashcode':
-        return FieldReflection<TestUserSimple, T>(
+        return FieldReflection<TestUserSimple, int>(
           this,
           TestUserSimple,
           __TR.tInt,
           'hashCode',
           false,
-          (o) => () => o!.hashCode as T,
+          (o) => () => o!.hashCode,
           null,
           obj,
           false,
@@ -425,19 +574,33 @@ class TestUserSimple$reflection extends ClassReflection<TestUserSimple>
   List<String> get staticFieldsNames =>
       const <String>['version', 'withReflection'];
 
+  static final Map<String, FieldReflection<TestUserSimple, dynamic>>
+      _staticFields = <String, FieldReflection<TestUserSimple, dynamic>>{};
+
   @override
   FieldReflection<TestUserSimple, T>? staticField<T>(String fieldName) {
+    var f = _staticFields[fieldName];
+    if (f != null) {
+      return f as FieldReflection<TestUserSimple, T>;
+    }
+    f = _staticFieldImpl(fieldName);
+    if (f == null) return null;
+    _staticFields[fieldName] = f;
+    return f as FieldReflection<TestUserSimple, T>;
+  }
+
+  FieldReflection<TestUserSimple, dynamic>? _staticFieldImpl(String fieldName) {
     var lc = fieldName.trim().toLowerCase();
 
     switch (lc) {
       case 'version':
-        return FieldReflection<TestUserSimple, T>(
+        return FieldReflection<TestUserSimple, double>(
           this,
           TestUserSimple,
           __TR.tDouble,
           'version',
           false,
-          (o) => () => TestUserSimple.version as T,
+          (o) => () => TestUserSimple.version,
           null,
           null,
           true,
@@ -447,13 +610,13 @@ class TestUserSimple$reflection extends ClassReflection<TestUserSimple>
           ],
         );
       case 'withreflection':
-        return FieldReflection<TestUserSimple, T>(
+        return FieldReflection<TestUserSimple, bool>(
           this,
           TestUserSimple,
           __TR.tBool,
           'withReflection',
           false,
-          (o) => () => TestUserSimple.withReflection as T,
+          (o) => () => TestUserSimple.withReflection,
           null,
           null,
           true,
@@ -469,16 +632,60 @@ class TestUserSimple$reflection extends ClassReflection<TestUserSimple>
   List<String> get methodsNames =>
       const <String>['checkThePassword', 'hasEmail', 'toString'];
 
+  static final Map<String, MethodReflection<TestUserSimple, dynamic>>
+      _methodsNoObject = <String, MethodReflection<TestUserSimple, dynamic>>{};
+
+  final Map<String, MethodReflection<TestUserSimple, dynamic>> _methodsObject =
+      <String, MethodReflection<TestUserSimple, dynamic>>{};
+
   @override
   MethodReflection<TestUserSimple, R>? method<R>(String methodName,
       [TestUserSimple? obj]) {
+    if (obj == null) {
+      if (object != null) {
+        return _methodObjectImpl<R>(methodName);
+      } else {
+        return _methodNoObjectImpl<R>(methodName);
+      }
+    } else if (identical(obj, object)) {
+      return _methodObjectImpl<R>(methodName);
+    }
+    return _methodNoObjectImpl<R>(methodName)?.withObject(obj);
+  }
+
+  MethodReflection<TestUserSimple, R>? _methodNoObjectImpl<R>(
+      String methodName) {
+    final m = _methodsNoObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestUserSimple, R>;
+    }
+    final m2 = _methodImpl(methodName, null);
+    if (m2 == null) return null;
+    _methodsNoObject[methodName] = m2;
+    return m2 as MethodReflection<TestUserSimple, R>;
+  }
+
+  MethodReflection<TestUserSimple, R>? _methodObjectImpl<R>(String methodName) {
+    final m = _methodsObject[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestUserSimple, R>;
+    }
+    var m2 = _methodNoObjectImpl<R>(methodName);
+    if (m2 == null) return null;
+    m2 = m2.withObject(object!);
+    _methodsObject[methodName] = m2;
+    return m2;
+  }
+
+  MethodReflection<TestUserSimple, dynamic>? _methodImpl(
+      String methodName, TestUserSimple? obj) {
     obj ??= object;
 
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'checkthepassword':
-        return MethodReflection<TestUserSimple, R>(
+        return MethodReflection<TestUserSimple, bool>(
             this,
             TestUserSimple,
             'checkThePassword',
@@ -500,7 +707,7 @@ class TestUserSimple$reflection extends ClassReflection<TestUserSimple>
               TestAnnotation(['method', 'password checker'])
             ]);
       case 'hasemail':
-        return MethodReflection<TestUserSimple, R>(
+        return MethodReflection<TestUserSimple, bool>(
             this,
             TestUserSimple,
             'hasEmail',
@@ -514,7 +721,7 @@ class TestUserSimple$reflection extends ClassReflection<TestUserSimple>
             null,
             null);
       case 'tostring':
-        return MethodReflection<TestUserSimple, R>(
+        return MethodReflection<TestUserSimple, String>(
             this,
             TestUserSimple,
             'toString',
@@ -535,13 +742,28 @@ class TestUserSimple$reflection extends ClassReflection<TestUserSimple>
   @override
   List<String> get staticMethodsNames => const <String>['isVersion'];
 
+  static final Map<String, MethodReflection<TestUserSimple, dynamic>>
+      _staticMethods = <String, MethodReflection<TestUserSimple, dynamic>>{};
+
   @override
   MethodReflection<TestUserSimple, R>? staticMethod<R>(String methodName) {
+    var m = _staticMethods[methodName];
+    if (m != null) {
+      return m as MethodReflection<TestUserSimple, R>;
+    }
+    m = _staticMethodImpl(methodName);
+    if (m == null) return null;
+    _staticMethods[methodName] = m;
+    return m as MethodReflection<TestUserSimple, R>;
+  }
+
+  MethodReflection<TestUserSimple, dynamic>? _staticMethodImpl(
+      String methodName) {
     var lc = methodName.trim().toLowerCase();
 
     switch (lc) {
       case 'isversion':
-        return MethodReflection<TestUserSimple, R>(
+        return MethodReflection<TestUserSimple, bool>(
             this,
             TestUserSimple,
             'isVersion',

--- a/test/src/user_with_reflection.dart
+++ b/test/src/user_with_reflection.dart
@@ -366,3 +366,23 @@ class TestTransactionWithReflection {
 
   TestTransactionWithReflection.fromTo(this.amount, this.fromUser, this.toUser);
 }
+
+@EnableReflection()
+class TestName {
+  String? name;
+
+  bool get isEmpty => nameNormalized().isEmpty;
+
+  String nameNormalized() {
+    var n = name ?? '';
+    return n.toLowerCase().trim();
+  }
+
+  @override
+  String toString() {
+    return 'TestName{name: $name}';
+  }
+}
+
+@EnableReflection()
+class TestEmpty {}


### PR DESCRIPTION
- `ClassReflection`:
  - `constructor`: - removed `<R>` type.
  - `field`:
    - Ggenerated implementation declares `T` of `FieldReflection<$class,T>` statically.
  - Optimized: - `allFields`, `allMethods`: object instances derived from cached `no-object` instances. - `construtor`, `staticField`, `field`, `method`:
      - Caching instances. - Object instances derived from cached `no-object` instances.
- `FieldReflection`:
  - Added `setNullable`.
- benchmark: ^0.3.0
  - `benchmark/reflection_factory_benchmark.dart`
- meta: ^1.9.0