### PR TITLE
2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.0.1
+
+- `ClassReflection.createInstanceWithBestConstructor`:
+  - Now throws `UnresolvedParameterError` instead of `StateError` for unresolved parameters.
+- analyzer: ^5.5.0
+- test: ^1.23.1
+- coverage: ^1.6.3
+
 ## 2.0.0
 
 - `ClassReflection`:

--- a/example/reflection_factory_bridge_example.reflection.g.dart
+++ b/example/reflection_factory_bridge_example.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.0.0
+// BUILDER: reflection_factory/2.0.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.0.0');
+  static final Version _version = Version.parse('2.0.1');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/example/reflection_factory_example.reflection.g.dart
+++ b/example/reflection_factory_example.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.0.0
+// BUILDER: reflection_factory/2.0.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.0.0');
+  static final Version _version = Version.parse('2.0.1');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reflection_factory
 description: Allows Dart reflection with an easy approach, even for third-party classes, using code generation portable for all Dart platforms.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/gmpassos/reflection_factory
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   build: ^2.3.1
-  analyzer: ^5.4.0
+  analyzer: ^5.5.0
   dart_style: ^2.2.4
   meta: ^1.9.0
   mime: ^1.0.4
@@ -26,6 +26,6 @@ dev_dependencies:
   pubspec: ^2.3.0
   data_serializer: ^1.0.7
   dependency_validator: ^3.2.2
-  test: ^1.22.2
-  coverage: ^1.6.2
+  test: ^1.23.1
+  coverage: ^1.6.3
   benchmark: ^0.3.0

--- a/test/reflection_factory_json_test.dart
+++ b/test/reflection_factory_json_test.dart
@@ -1484,10 +1484,8 @@ void main() {
               () => jsonCodec.decode(encodedJson,
                   type: TestTransactionWithReflection,
                   duplicatedEntitiesAsID: true),
-              throwsA(isA<StateError>().having(
-                  (e) => e.message,
-                  'With unresolved_parameter',
-                  contains('<unresolved_parameter>'))));
+              throwsA(isA<UnresolvedParameterError>().having((e) => e.message,
+                  'message', contains('<unresolved_parameter>'))));
         }
 
         {
@@ -1500,7 +1498,7 @@ void main() {
               () => jsonCodec.decode(encodedJson,
                   type: TestTransactionWithReflection,
                   duplicatedEntitiesAsID: true),
-              throwsA(isA<StateError>().having(
+              throwsA(isA<UnresolvedParameterError>().having(
                   (e) => e.message,
                   'With unresolved_parameter',
                   contains('<unresolved_parameter>'))));

--- a/test/src/reflection/user_with_reflection.g.dart
+++ b/test/src/reflection/user_with_reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.0.0
+// BUILDER: reflection_factory/2.0.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.0.0');
+  static final Version _version = Version.parse('2.0.1');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/src/user_reflection_bridge.reflection.g.dart
+++ b/test/src/user_reflection_bridge.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.0.0
+// BUILDER: reflection_factory/2.0.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.0.0');
+  static final Version _version = Version.parse('2.0.1');
 
   Version get reflectionFactoryVersion => _version;
 


### PR DESCRIPTION
- `ClassReflection.createInstanceWithBestConstructor`:
  - Now throws `UnresolvedParameterError` instead of `StateError` for unresolved parameters.
- analyzer: ^5.5.0
- test: ^1.23.1
- coverage: ^1.6.3