### PR TITLE
🐛 fix(builder): use raw strings on class names

### DIFF
--- a/example/reflection_factory_bridge_example.reflection.g.dart
+++ b/example/reflection_factory_bridge_example.reflection.g.dart
@@ -42,7 +42,7 @@ class User$reflection extends ClassReflection<User> with __ReflectionMixin {
     return _objectReflections[object] ??= User$reflection._(object);
   }
 
-  User$reflection._([User? object]) : super(User, 'User', object);
+  User$reflection._([User? object]) : super(User, r'User', object);
 
   static bool _registered = false;
   @override

--- a/example/reflection_factory_example.reflection.g.dart
+++ b/example/reflection_factory_example.reflection.g.dart
@@ -42,7 +42,7 @@ class User$reflection extends ClassReflection<User> with __ReflectionMixin {
     return _objectReflections[object] ??= User$reflection._(object);
   }
 
-  User$reflection._([User? object]) : super(User, 'User', object);
+  User$reflection._([User? object]) : super(User, r'User', object);
 
   static bool _registered = false;
   @override

--- a/lib/src/reflection_factory_builder.dart
+++ b/lib/src/reflection_factory_builder.dart
@@ -1274,7 +1274,7 @@ class _EnumTree<T> extends RecursiveElementVisitor<T> {
     }
 
     str.write(
-        '  $reflectionClass._([$enumName? object]) : super($enumName, \'$enumName\', object);\n\n');
+        '  $reflectionClass._([$enumName? object]) : super($enumName, r\'$enumName\', object);\n\n');
 
     str.write('  static bool _registered = false;\n');
     str.write('  @override\n');
@@ -1734,7 +1734,7 @@ class _ClassTree<T> extends RecursiveElementVisitor<T> {
     }
 
     str.write(
-        '  $reflectionClass._([$className? object]) : super($className, \'$className\', object);\n\n');
+        '  $reflectionClass._([$className? object]) : super($className, r\'$className\', object);\n\n');
 
     str.write('  static bool _registered = false;\n');
     str.write('  @override\n');

--- a/test/src/reflection/user_with_reflection.g.dart
+++ b/test/src/reflection/user_with_reflection.g.dart
@@ -136,7 +136,7 @@ class TestAddressWithReflection$reflection
       : this._(object);
 
   TestAddressWithReflection$reflection._([TestAddressWithReflection? object])
-      : super(TestAddressWithReflection, 'TestAddressWithReflection', object);
+      : super(TestAddressWithReflection, r'TestAddressWithReflection', object);
 
   static bool _registered = false;
   @override
@@ -533,7 +533,7 @@ class TestCompanyWithReflection$reflection
   }
 
   TestCompanyWithReflection$reflection._([TestCompanyWithReflection? object])
-      : super(TestCompanyWithReflection, 'TestCompanyWithReflection', object);
+      : super(TestCompanyWithReflection, r'TestCompanyWithReflection', object);
 
   static bool _registered = false;
   @override
@@ -1009,7 +1009,7 @@ class TestDataWithReflection$reflection
   }
 
   TestDataWithReflection$reflection._([TestDataWithReflection? object])
-      : super(TestDataWithReflection, 'TestDataWithReflection', object);
+      : super(TestDataWithReflection, r'TestDataWithReflection', object);
 
   static bool _registered = false;
   @override
@@ -1313,7 +1313,7 @@ class TestDomainWithReflection$reflection
   }
 
   TestDomainWithReflection$reflection._([TestDomainWithReflection? object])
-      : super(TestDomainWithReflection, 'TestDomainWithReflection', object);
+      : super(TestDomainWithReflection, r'TestDomainWithReflection', object);
 
   static bool _registered = false;
   @override
@@ -1762,7 +1762,7 @@ class TestEmpty$reflection extends ClassReflection<TestEmpty>
   }
 
   TestEmpty$reflection._([TestEmpty? object])
-      : super(TestEmpty, 'TestEmpty', object);
+      : super(TestEmpty, r'TestEmpty', object);
 
   static bool _registered = false;
   @override
@@ -1912,7 +1912,7 @@ class TestEnumWithReflection$reflection
   }
 
   TestEnumWithReflection$reflection._([TestEnumWithReflection? object])
-      : super(TestEnumWithReflection, 'TestEnumWithReflection', object);
+      : super(TestEnumWithReflection, r'TestEnumWithReflection', object);
 
   static bool _registered = false;
   @override
@@ -1998,8 +1998,8 @@ class TestFranchiseWithReflection$reflection
 
   TestFranchiseWithReflection$reflection._(
       [TestFranchiseWithReflection? object])
-      : super(
-            TestFranchiseWithReflection, 'TestFranchiseWithReflection', object);
+      : super(TestFranchiseWithReflection, r'TestFranchiseWithReflection',
+            object);
 
   static bool _registered = false;
   @override
@@ -2347,7 +2347,7 @@ class TestName$reflection extends ClassReflection<TestName>
   }
 
   TestName$reflection._([TestName? object])
-      : super(TestName, 'TestName', object);
+      : super(TestName, r'TestName', object);
 
   static bool _registered = false;
   @override
@@ -2654,7 +2654,7 @@ class TestOpAWithReflection$reflection
   }
 
   TestOpAWithReflection$reflection._([TestOpAWithReflection? object])
-      : super(TestOpAWithReflection, 'TestOpAWithReflection', object);
+      : super(TestOpAWithReflection, r'TestOpAWithReflection', object);
 
   static bool _registered = false;
   @override
@@ -3019,7 +3019,7 @@ class TestOpBWithReflection$reflection
   }
 
   TestOpBWithReflection$reflection._([TestOpBWithReflection? object])
-      : super(TestOpBWithReflection, 'TestOpBWithReflection', object);
+      : super(TestOpBWithReflection, r'TestOpBWithReflection', object);
 
   static bool _registered = false;
   @override
@@ -3403,7 +3403,7 @@ class TestOpWithReflection$reflection
   }
 
   TestOpWithReflection$reflection._([TestOpWithReflection? object])
-      : super(TestOpWithReflection, 'TestOpWithReflection', object);
+      : super(TestOpWithReflection, r'TestOpWithReflection', object);
 
   static bool _registered = false;
   @override
@@ -3803,7 +3803,7 @@ class TestTransactionWithReflection$reflection
 
   TestTransactionWithReflection$reflection._(
       [TestTransactionWithReflection? object])
-      : super(TestTransactionWithReflection, 'TestTransactionWithReflection',
+      : super(TestTransactionWithReflection, r'TestTransactionWithReflection',
             object);
 
   static bool _registered = false;
@@ -4082,7 +4082,7 @@ class TestUserWithReflection$reflection
   }
 
   TestUserWithReflection$reflection._([TestUserWithReflection? object])
-      : super(TestUserWithReflection, 'TestUserWithReflection', object);
+      : super(TestUserWithReflection, r'TestUserWithReflection', object);
 
   static bool _registered = false;
   @override

--- a/test/src/user_reflection_bridge.reflection.g.dart
+++ b/test/src/user_reflection_bridge.reflection.g.dart
@@ -54,7 +54,7 @@ class TestAddress$reflection extends ClassReflection<TestAddress>
   }
 
   TestAddress$reflection._([TestAddress? object])
-      : super(TestAddress, 'TestAddress', object);
+      : super(TestAddress, r'TestAddress', object);
 
   static bool _registered = false;
   @override
@@ -378,7 +378,7 @@ class TestUserSimple$reflection extends ClassReflection<TestUserSimple>
   }
 
   TestUserSimple$reflection._([TestUserSimple? object])
-      : super(TestUserSimple, 'TestUserSimple', object);
+      : super(TestUserSimple, r'TestUserSimple', object);
 
   static bool _registered = false;
   @override


### PR DESCRIPTION
When usign reflection on class names beggining with `$`
Errors appear in the generated file.

By using raw strings, we avoid unwanted string interpolation 
